### PR TITLE
Master ltr plugin rfc

### DIFF
--- a/dev-tools/idea/.idea/modules.xml
+++ b/dev-tools/idea/.idea/modules.xml
@@ -58,6 +58,7 @@
       <module group="Solr/Contrib" filepath="$PROJECT_DIR$/solr/contrib/uima/uima.iml" />
       <module group="Solr/Contrib" filepath="$PROJECT_DIR$/solr/contrib/velocity/velocity.iml" />
       <module group="Solr/Contrib" filepath="$PROJECT_DIR$/solr/contrib/analytics/analytics.iml" />
+      <module group="Solr/Contrib" filepath="$PROJECT_DIR$/solr/contrib/ltr/ltr.iml" />
     </modules>
   </component>
 </project>

--- a/dev-tools/idea/solr/contrib/ltr/ltr.iml
+++ b/dev-tools/idea/solr/contrib/ltr/ltr.iml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../../idea-build/solr/contrib/ltr/classes/java" />
+    <output-test url="file://$MODULE_DIR$/../../../idea-build/solr/contrib/ltr/classes/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/test" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test-files" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/resources" type="java-resource" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="TEST" name="JUnit" level="project" />
+    <orderEntry type="library" name="Solr core library" level="project" />
+    <orderEntry type="library" name="Solrj library" level="project" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="file://$MODULE_DIR$/lib" recursive="false" />
+      </library>
+    </orderEntry>
+    <orderEntry type="library" scope="TEST" name="Solr example library" level="project" />
+    <orderEntry type="library" scope="TEST" name="Solr core test library" level="project" />
+    <orderEntry type="module" scope="TEST" module-name="lucene-test-framework" />
+    <orderEntry type="module" scope="TEST" module-name="solr-test-framework" />
+    <orderEntry type="module" module-name="solr-core" />
+    <orderEntry type="module" module-name="solrj" />
+    <orderEntry type="module" module-name="lucene-core" />
+    <orderEntry type="module" module-name="analysis-common" />
+  </component>
+</module>

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/SolrFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/SolrFeature.java
@@ -78,7 +78,9 @@ public class SolrFeature extends Feature {
         if (solrQuery == null || solrQuery.isEmpty()) {
           solrQuery = "*:*";
         }
-        solrQuery = macroExpander.expand(solrQuery);
+        String expandedQuery = macroExpander.expand(solrQuery);
+        if(expandedQuery!=null)
+            solrQuery = expandedQuery;
 
         SolrQueryRequest req = makeRequest(request.getCore(), solrQuery, fqs,
             df);

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
@@ -69,7 +69,7 @@ public class ValueFeature extends Feature {
 
   public class ValueFeatureWeight extends FeatureWeight {
 
-    protected float featureValue;
+    protected Float featureValue;
 
     public ValueFeatureWeight(IndexSearcher searcher, String name,
         NamedParams params, Normalizer norm, int id) {
@@ -84,7 +84,9 @@ public class ValueFeature extends Feature {
       // otherwise use the
       // constant value provided in the config.
       if (configValueStr != null) {
-        featureValue = Float.parseFloat(macroExpander.expand(configValueStr));
+        String expandedValue = macroExpander.expand(configValueStr);
+        if(expandedValue!=null)
+          featureValue = Float.parseFloat(expandedValue);
       } else {
         featureValue = configValue;
       }
@@ -92,7 +94,10 @@ public class ValueFeature extends Feature {
 
     @Override
     public FeatureScorer scorer(LeafReaderContext context) throws IOException {
-      return new ValueFeatureScorer(this, featureValue, "ValueFeature");
+      if(featureValue!=null)
+        return new ValueFeatureScorer(this, featureValue, "ValueFeature");
+      else
+        return null;
     }
 
     /**

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/FeatureWeight.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/FeatureWeight.java
@@ -124,8 +124,9 @@ public abstract class FeatureWeight extends Weight {
       r.iterator().advance(doc);
       if (r.docID() == doc) score = r.score();
       return Explanation.match(score, r.toString());
+    }else{
+      return Explanation.match(score, "The feature has no value");
     }
-    return null;
 
   }
 

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/FeatureWeight.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/FeatureWeight.java
@@ -119,11 +119,14 @@ public abstract class FeatureWeight extends Weight {
   public Explanation explain(LeafReaderContext context, int doc)
       throws IOException {
     FeatureScorer r = scorer(context);
-    r.iterator().advance(doc);
     float score = getDefaultValue();
-    if (r.docID() == doc) score = r.score();
+    if (r != null) {
+      r.iterator().advance(doc);
+      if (r.docID() == doc) score = r.score();
+      return Explanation.match(score, r.toString());
+    }
+    return null;
 
-    return Explanation.match(score, r.toString());
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/LambdaMARTModel.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/LambdaMARTModel.java
@@ -52,7 +52,7 @@ public class LambdaMARTModel extends ModelMetadata {
       }
 
       if (featureIndex < 0 || // unsupported feature
-          featureIndex > featureVector.length || // tree is looking for a
+          featureIndex >= featureVector.length || // tree is looking for a
                                                  // feature that does not
                                                  // exist
           featureVector[featureIndex] <= threshold) {

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
@@ -100,7 +100,7 @@ public class ModelQuery extends Query {
     result = prime * result + ((meta == null) ? 0 : meta.hashCode());
     result = prime * result
         + ((originalQuery == null) ? 0 : originalQuery.hashCode());
-    result = prime * result + ((efi == null) ? 0 : originalQuery.hashCode());
+    result = prime * result + ((efi == null) ? 0 : efi.hashCode());
     result = prime * result + this.toString().hashCode();
     return result;
   }

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
@@ -36,7 +36,6 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.search.Scorer.ChildScorer;
 import org.apache.solr.ltr.feature.ModelMetadata;
 import org.apache.solr.ltr.feature.norm.Normalizer;
 import org.apache.solr.ltr.feature.norm.impl.IdentityNormalizer;
@@ -218,18 +217,16 @@ public class ModelQuery extends Query {
       int index = 0;
       for (FeatureWeight feature : allFeatureWeights) {
         Explanation featureExplanation = feature.explain(context, doc);
-        if(featureExplanation!=null)
-            explanations[index++] = featureExplanation;
+        explanations[index++] = featureExplanation;
       }
 
       List<Explanation> featureExplanations = new ArrayList<>();
       for (FeatureWeight f : modelFeatures) {
         Normalizer n = f.getNorm();
         Explanation e = explanations[f.id];
-        if(e!=null) {
           if (n != IdentityNormalizer.INSTANCE) e = n.explain(e);
           featureExplanations.add(e);
-        }
+
       }
       // TODO this calls twice the scorers, could be optimized.
       ModelScorer bs = scorer(context);

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
@@ -217,15 +217,19 @@ public class ModelQuery extends Query {
       Explanation[] explanations = new Explanation[allFeatureValues.length];
       int index = 0;
       for (FeatureWeight feature : allFeatureWeights) {
-        explanations[index++] = feature.explain(context, doc);
+        Explanation featureExplanation = feature.explain(context, doc);
+        if(featureExplanation!=null)
+            explanations[index++] = featureExplanation;
       }
 
       List<Explanation> featureExplanations = new ArrayList<>();
       for (FeatureWeight f : modelFeatures) {
         Normalizer n = f.getNorm();
         Explanation e = explanations[f.id];
-        if (n != IdentityNormalizer.INSTANCE) e = n.explain(e);
-        featureExplanations.add(e);
+        if(e!=null) {
+          if (n != IdentityNormalizer.INSTANCE) e = n.explain(e);
+          featureExplanations.add(e);
+        }
       }
       // TODO this calls twice the scorers, could be optimized.
       ModelScorer bs = scorer(context);

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/util/MacroExpander.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/util/MacroExpander.java
@@ -96,7 +96,14 @@ public class MacroExpander {
       if (replacement != null) {
         sb.append(replacement);
       } else {
-        sb.append(val.substring(matchedStart, start));
+        /*
+        int defaultValueIdx=val.indexOf(":",matchedStart);
+        if(defaultValueIdx>start)
+          sb.append(val.substring(matchedStart, start));
+        else
+          sb.append(val.substring(defaultValueIdx+1, start-1));
+          */
+        return null;
       }
 
     }

--- a/solr/contrib/ltr/src/test-files/featureExamples/external_features_for_sparse_processing.json
+++ b/solr/contrib/ltr/src/test-files/featureExamples/external_features_for_sparse_processing.json
@@ -1,0 +1,18 @@
+[{
+        "name" : "user_device_smartphone",
+        "type":"org.apache.solr.ltr.feature.impl.ValueFeature",
+        "params" : {
+            "value": "${user_device_smartphone}"
+        }
+    },
+  {
+    "name" : "user_device_tablet",
+    "type":"org.apache.solr.ltr.feature.impl.ValueFeature",
+    "params" : {
+      "value": "${user_device_tablet}"
+    }
+  }
+
+
+
+]

--- a/solr/contrib/ltr/src/test-files/featureExamples/features-ranksvm-efi.json
+++ b/solr/contrib/ltr/src/test-files/featureExamples/features-ranksvm-efi.json
@@ -1,0 +1,17 @@
+[
+ {
+   "name": "sampleConstant",
+   "type": "org.apache.solr.ltr.feature.impl.ValueFeature",
+   "params": {
+       "value": 5
+   }
+ },
+  {
+    "name" : "search_number_of_nights",
+    "type":"org.apache.solr.ltr.feature.impl.ValueFeature",
+    "params" : {
+      "value": "${search_number_of_nights}"
+    }
+  }
+
+]

--- a/solr/contrib/ltr/src/test-files/modelExamples/external_model_binary_feature.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/external_model_binary_feature.json
@@ -1,0 +1,38 @@
+{
+"type":"org.apache.solr.ltr.ranking.LambdaMARTModel",
+"name":"external_model_binary_feature",
+"features":[
+{ "name": "user_device_smartphone"},
+{ "name": "user_device_tablet"}
+],
+"params":{
+"trees": [
+{
+"weight" : 1,
+"tree": {
+"feature": "user_device_smartphone",
+"threshold": 0.5,
+"left" : {
+"value" : 0
+},
+"right" : {
+"value" : 50
+}
+
+}},
+    {
+        "weight" : 1,
+        "tree": {
+            "feature": "user_device_tablet",
+            "threshold": 0.5,
+            "left" : {
+                "value" : 0
+            },
+            "right" : {
+                "value" : 65
+            }
+
+        }}
+]
+}
+}

--- a/solr/contrib/ltr/src/test-files/modelExamples/svm-model-efi.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/svm-model-efi.json
@@ -1,0 +1,14 @@
+{
+	"type":"org.apache.solr.ltr.ranking.RankSVMModel",
+	"name":"svm-efi",
+	"features":[
+		{"name":"sampleConstant"},
+	    {"name":"search_number_of_nights"}
+	],
+	 "params":{
+     "weights":{
+       "sampleConstant":1.0,
+       "search_number_of_nights":2.0
+     }
+  }
+}

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestValueFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestValueFeature.java
@@ -124,7 +124,7 @@ public class TestValueFeature extends TestRerankBase {
     // System.out.println(res);
 
     // No efi.val passed in
-    assertJQ("/query" + query.toQueryString(), "/responseHeader/status==400");
+    assertJQ("/query" + query.toQueryString(), "/responseHeader/status==0");
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestLTRQParserExplain.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestLTRQParserExplain.java
@@ -112,6 +112,30 @@ public class TestLTRQParserExplain extends TestRerankBase {
         "/debug/explain/9=='\n3.5116758 = 6029760550880411648 [ org.apache.solr.ltr.ranking.RankSVMModel ] model applied to features, sum of:\n  0.0 = prod of:\n    0.0 = weight on feature [would be cool to have the name :)]\n    1.0 = ValueFeature [name=title value=1.0]\n  0.2 = prod of:\n    0.1 = weight on feature [would be cool to have the name :)]\n    2.0 = ValueFeature [name=description value=2.0]\n  0.4 = prod of:\n    0.2 = weight on feature [would be cool to have the name :)]\n    2.0 = ValueFeature [name=keywords value=2.0]\n  0.09 = prod of:\n    0.3 = weight on feature [would be cool to have the name :)]\n    0.3 = normalized using org.apache.solr.ltr.feature.norm.impl.MinMaxNormalizer [params {min=0.0, max=10.0}]\n      3.0 = ValueFeature [name=popularity value=3.0]\n  1.6 = prod of:\n    0.4 = weight on feature [would be cool to have the name :)]\n    4.0 = ValueFeature [name=text value=4.0]\n  0.6156155 = prod of:\n    0.1231231 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=queryIntentPerson value=5.0]\n  0.60606056 = prod of:\n    0.12121211 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=queryIntentCompany value=5.0]\n'}");
   }
 
+  @Test
+  public void scoreExplain_missingEfiFeature_shouldReturnDefaultScore() throws Exception {
+    loadFeatures("features-ranksvm-efi.json");
+    loadModels("svm-model-efi.json");
+
+    SolrQuery query = new SolrQuery();
+    query.setQuery("title:bloomberg");
+    query.setParam("debugQuery", "on");
+    query.add("rows", "4");
+    query.add("rq", "{!ltr reRankDocs=4 model=svm-efi}");
+    query.add("fl", "*,score");
+    query.add("wt", "xml");
+
+    System.out.println(restTestHarness.query("/query" + query.toQueryString()));
+    query.remove("wt");
+    query.add("wt", "json");
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/debug/explain/7=='\n5.0 = svm-efi [ org.apache.solr.ltr.ranking.RankSVMModel ] model applied to features, sum of:\n  5.0 = prod of:\n    1.0 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=sampleConstant value=5.0]\n'}");
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/debug/explain/9=='\n5.0 = svm-efi [ org.apache.solr.ltr.ranking.RankSVMModel ] model applied to features, sum of:\n  5.0 = prod of:\n    1.0 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=sampleConstant value=5.0]\n'}");
+  }
+
   // @Test
   // public void checkfq() throws Exception {
   //

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/util/TestMacroExpander.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/util/TestMacroExpander.java
@@ -18,6 +18,7 @@ package org.apache.solr.ltr.util;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,9 +35,9 @@ public class TestMacroExpander {
     assertEquals("", macroExpander.expand(""));
     assertEquals("foo", macroExpander.expand("foo"));
     assertEquals("$foo", macroExpander.expand("$foo"));
-    assertEquals("${foo}", macroExpander.expand("${foo}"));
+    assertNull( macroExpander.expand("${foo}"));
     assertEquals("{foo}", macroExpander.expand("{foo}"));
-    assertEquals("${foo}", MacroExpander.expand("${foo}", efi));
+    assertNull( MacroExpander.expand("${foo}", efi));
   }
 
   @Test


### PR DESCRIPTION
- added intelliJ support
- fixed wrong hashcode generation
- added sparse efi support 

Related the  sparse efi support this is mainly for categorical features encoded in binaries features.
Based on the different observations per category we could end up in a lot of binaries feature.
Instead of passing and caching all of them ( even the one that are actually 0) I propose to avoid the scoring for the null features.
This could have side effect, so please, any feedback is welcome.
Tests are passing.

e.g.
shirt_color_blue
shirt_color_red
shirt_color_yellow
shirt_color_green

**Current scenario **
For a blue shirt I need to pass :
efi.color_blue=1 efi.color_red=0 efi.color_yellow=0 efi.color_green=0

This will end up in that feature vector and in the cache as well, we store this.
If i pass only efi.color_blue=1, an error appears .

**Patch**
For a blue shirt I need to pass :
efi.color_blue=1 

The other feature scorers are skipped, so I have only that value.
Both LambdaMART and SVN react correctly in the case we don't have the feature value ( the array of feature scores is initialized with 0.0) .

**Possible Improvement**
Adding a default value can be simple as well, 
you define in the feature.json the default value and this is expanded when no efi is passed.
