### PR TITLE
Sparse Efi Feature Support where no default #9

### DIFF
--- a/solr/contrib/ltr/README.md
+++ b/solr/contrib/ltr/README.md
@@ -159,7 +159,12 @@ using standard Solr queries. As an example:
   "name" : "userTextTitleMatch",
   "type" : "org.apache.solr.ltr.feature.impl.SolrFeature",
   "params" : { "q" : "{!field f=title}${user_text}" }
-}
+},
+ {
+   "name" : "userFromMobile",
+   "type" : "org.apache.solr.ltr.feature.impl.ValueFeature",
+   "params" : { "value" : ${userFromMobile}, "required":true }
+ }
 ]
 ```
 
@@ -194,6 +199,11 @@ called 'user_text' passed in through the request, and will fire if there is
 a term match for the document field 'title' from the value of the external
 field 'user_text'.  You can provide default values for external features as
 well by specifying ${myField:myDefault}, similar to how you would in a Solr config.
+In this case, the fifth feature (userFromMobile) will be looking for an external parameter
+called 'userFromMobile' passed in through the request, if the ValueFeature is :
+required=true, it will throw an exception if the external feature is not passed
+required=false, it will silently ignore the feature and avoid the scoring ( at Document scoring time, the model will consider 0 as feature value)
+The advantage in defining a feature as not required, where possible, is to avoid wasting caching space and time in calculating the featureScore.
 See the [Run a Rerank Query](#run-a-rerank-query) section for how to pass in external information.
 
 ### Custom Features

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
@@ -33,12 +33,13 @@ import org.apache.solr.ltr.util.NamedParams;
 import org.apache.solr.request.SolrQueryRequest;
 
 public class ValueFeature extends Feature {
+  /** name of the attribute containing the value of this feature **/
+  private static final String VALUE_FIELD = "value";
+  private static final String REQUIRED_PARAM = "required";
 
   protected float configValue = -1f;
   protected String configValueStr = null;
   protected boolean required = false;
-  /** name of the attribute containing the value of this feature **/
-  private static final String VALUE_FIELD = "value";
 
   public ValueFeature() {}
 
@@ -46,7 +47,7 @@ public class ValueFeature extends Feature {
   public void init(String name, NamedParams params, int id)
       throws FeatureException {
     super.init(name, params, id);
-    final Object paramRequired = params.get("required");
+    final Object paramRequired = params.get(REQUIRED_PARAM);
     if (paramRequired != null)
       this.required = (boolean) paramRequired;
     final Object paramValue = params.get(VALUE_FIELD);

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
@@ -74,18 +74,20 @@ public class ValueFeature extends Feature {
 
   public class ValueFeatureWeight extends FeatureWeight {
 
-    final protected float featureValue;
+    final protected Float featureValue;
 
     public ValueFeatureWeight(IndexSearcher searcher, String name,
         NamedParams params, Normalizer norm, int id, SolrQueryRequest request, Query originalQuery, Map<String,String> efi) {
       super(ValueFeature.this, searcher, name, params, norm, id, request, originalQuery, efi);
       if (configValueStr != null) {
         final String expandedValue = macroExpander.expand(configValueStr);
-        if (expandedValue == null) {
-          throw new FeatureException(this.getClass().getCanonicalName()+" requires efi parameter that was not passed in request.");
+        if (expandedValue != null) {
+          featureValue = Float.parseFloat(expandedValue);
+        }else{
+          featureValue=null;
         }
 
-        featureValue = Float.parseFloat(expandedValue);
+
       } else {
         featureValue = configValue;
       }
@@ -93,7 +95,10 @@ public class ValueFeature extends Feature {
 
     @Override
     public FeatureScorer scorer(LeafReaderContext context) throws IOException {
-      return new ValueFeatureScorer(this, featureValue, "ValueFeature");
+      if(featureValue!=null)
+        return new ValueFeatureScorer(this, featureValue, "ValueFeature");
+      else
+        return null;
     }
 
     /**

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
@@ -36,6 +36,7 @@ public class ValueFeature extends Feature {
 
   protected float configValue = -1f;
   protected String configValueStr = null;
+  protected boolean required = false;
   /** name of the attribute containing the value of this feature **/
   private static final String VALUE_FIELD = "value";
 
@@ -45,6 +46,9 @@ public class ValueFeature extends Feature {
   public void init(String name, NamedParams params, int id)
       throws FeatureException {
     super.init(name, params, id);
+    final Object paramRequired = params.get("required");
+    if (paramRequired != null)
+      this.required = (boolean) paramRequired;
     final Object paramValue = params.get(VALUE_FIELD);
     if (paramValue == null) {
       throw new FeatureException("Missing the field 'value' in params for "
@@ -83,7 +87,9 @@ public class ValueFeature extends Feature {
         final String expandedValue = macroExpander.expand(configValueStr);
         if (expandedValue != null) {
           featureValue = Float.parseFloat(expandedValue);
-        }else{
+        } else if (required) {
+          throw new FeatureException(this.getClass().getCanonicalName() + " requires efi parameter that was not passed in request.");
+        } else {
           featureValue=null;
         }
 

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/FeatureWeight.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/FeatureWeight.java
@@ -108,13 +108,14 @@ public abstract class FeatureWeight extends Weight {
   public Explanation explain(LeafReaderContext context, int doc)
       throws IOException {
     final FeatureScorer r = scorer(context);
-    r.iterator().advance(doc);
     float score = getDefaultValue();
-    if (r.docID() == doc) {
-      score = r.score();
+    if (r != null) {
+      r.iterator().advance(doc);
+      if (r.docID() == doc) score = r.score();
+      return Explanation.match(score, r.toString());
+    }else{
+      return Explanation.match(score, "The feature has no value");
     }
-
-    return Explanation.match(score, r.toString());
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/LambdaMARTModel.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/LambdaMARTModel.java
@@ -52,7 +52,7 @@ public class LambdaMARTModel extends LTRScoringAlgorithm {
       }
 
       if ((featureIndex < 0) || // unsupported feature
-          (featureIndex > featureVector.length) /*
+          (featureIndex >= featureVector.length) /*
                                                  * tree is looking for a feature
                                                  * that does not exist
                                                  */

--- a/solr/contrib/ltr/src/test-files/featureExamples/external_features.json
+++ b/solr/contrib/ltr/src/test-files/featureExamples/external_features.json
@@ -17,6 +17,32 @@
     "store": "fstore2",
     "params":{}
 }, {
+    "name" : "occurrences",
+    "type" : "org.apache.solr.ltr.feature.impl.ValueFeature",
+    "store": "fstore3",
+    "params" : {
+        "value" : "${myOcc}",
+        "required" : false
+    }
+}, {
+    "name":"originalScore",
+    "type":"org.apache.solr.ltr.feature.impl.OriginalScoreFeature",
+    "store": "fstore3",
+    "params":{}
+}, {
+    "name" : "popularity",
+    "type" : "org.apache.solr.ltr.feature.impl.ValueFeature",
+    "store": "fstore4",
+    "params" : {
+        "value" : "${myPop}",
+        "required" : true
+    }
+}, {
+    "name":"originalScore",
+    "type":"org.apache.solr.ltr.feature.impl.OriginalScoreFeature",
+    "store": "fstore4",
+    "params":{}
+}, {
     "name" : "titlePhraseMatch",
     "type" : "org.apache.solr.ltr.feature.impl.SolrFeature",
     "params" : {

--- a/solr/contrib/ltr/src/test-files/featureExamples/external_features_for_sparse_processing.json
+++ b/solr/contrib/ltr/src/test-files/featureExamples/external_features_for_sparse_processing.json
@@ -1,0 +1,18 @@
+[{
+  "name" : "user_device_smartphone",
+  "type":"org.apache.solr.ltr.feature.impl.ValueFeature",
+  "params" : {
+    "value": "${user_device_smartphone}"
+  }
+},
+  {
+    "name" : "user_device_tablet",
+    "type":"org.apache.solr.ltr.feature.impl.ValueFeature",
+    "params" : {
+      "value": "${user_device_tablet}"
+    }
+  }
+
+
+
+]

--- a/solr/contrib/ltr/src/test-files/featureExamples/features-ranksvm-efi.json
+++ b/solr/contrib/ltr/src/test-files/featureExamples/features-ranksvm-efi.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "sampleConstant",
+    "type": "org.apache.solr.ltr.feature.impl.ValueFeature",
+    "params": {
+      "value": 5
+    }
+  },
+  {
+    "name" : "search_number_of_nights",
+    "type":"org.apache.solr.ltr.feature.impl.ValueFeature",
+    "params" : {
+      "value": "${search_number_of_nights}"
+    }
+  }
+
+]

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_external_binary_features.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_external_binary_features.json
@@ -1,0 +1,38 @@
+{
+  "type":"org.apache.solr.ltr.ranking.LambdaMARTModel",
+  "name":"external_model_binary_feature",
+  "features":[
+    { "name": "user_device_smartphone"},
+    { "name": "user_device_tablet"}
+  ],
+  "params":{
+    "trees": [
+      {
+        "weight" : 1,
+        "tree": {
+          "feature": "user_device_smartphone",
+          "threshold": 0.5,
+          "left" : {
+            "value" : 0
+          },
+          "right" : {
+            "value" : 50
+          }
+
+        }},
+      {
+        "weight" : 1,
+        "tree": {
+          "feature": "user_device_tablet",
+          "threshold": 0.5,
+          "left" : {
+            "value" : 0
+          },
+          "right" : {
+            "value" : 65
+          }
+
+        }}
+    ]
+  }
+}

--- a/solr/contrib/ltr/src/test-files/modelExamples/svm-model-efi.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/svm-model-efi.json
@@ -1,0 +1,14 @@
+{
+  "type":"org.apache.solr.ltr.ranking.RankSVMModel",
+  "name":"svm-efi",
+  "features":[
+    {"name":"sampleConstant"},
+    {"name":"search_number_of_nights"}
+  ],
+  "params":{
+    "weights":{
+      "sampleConstant":1.0,
+      "search_number_of_nights":2.0
+    }
+  }
+}

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestExternalFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestExternalFeatures.java
@@ -113,10 +113,6 @@ public class TestExternalFeatures extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/error/msg=='Exception from createWeight for Feature [name=matchedTitle, type=SolrFeature, id=0, params={q={!terms f=title}${user_query}}] org.apache.solr.ltr.feature.impl.SolrFeature.SolrFeatureWeight requires efi parameter that was not passed in request.'");
 
-    // Using nondefault store should still result in error with no efi
-    query.remove("fl");
-    query.add("fl", "fvalias:[fv store=fstore2]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore:0.0'");
     // Adding efi in features section should make it work
     query.remove("fl");
     query.add("fl", "score,fvalias:[fv store=fstore2 efi.myconf=2.3]");
@@ -127,5 +123,41 @@ public class TestExternalFeatures extends TestRerankBase {
     query.add("fl", "score,fvalias:[fv store=fstore2 efi.myconf=2.3]");
     query.add("rq", "{!ltr reRankDocs=3 model=externalmodel efi.user_query=w3}");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='confidence:2.3;originalScore:1.0'");
+  }
+
+  @Test
+  public void featureExtraction_valueFeatureImplicitlyNotRequired_shouldNotScoreFeature() throws Exception {
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("*:*");
+    query.add("rows", "1");
+
+    // Efi is explicitly not required, so we do not score the feature
+    query.remove("fl");
+    query.add("fl", "fvalias:[fv store=fstore2]");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore:0.0'");
+  }
+
+  @Test
+  public void featureExtraction_valueFeatureExplicitlyNotRequired_shouldNotScoreFeature() throws Exception {
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("*:*");
+    query.add("rows", "1");
+
+    // Efi is explicitly not required, so we do not score the feature
+    query.remove("fl");
+    query.add("fl", "fvalias:[fv store=fstore3]");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore:0.0'");
+  }
+
+  @Test
+  public void featureExtraction_valueFeatureRequired_shouldThrowException() throws Exception {
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("*:*");
+    query.add("rows", "1");
+
+    // Using nondefault store should still result in error with no efi when it is required (myPop)
+    query.remove("fl");
+    query.add("fl", "fvalias:[fv store=fstore4]");
+    assertJQ("/query" + query.toQueryString(), "/error/msg=='Exception from createWeight for Feature [name=popularity, type=ValueFeature, id=0, params={value=${myPop}, required=true}] org.apache.solr.ltr.feature.impl.ValueFeature.ValueFeatureWeight requires efi parameter that was not passed in request.'");
   }
 }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestExternalFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestExternalFeatures.java
@@ -115,9 +115,8 @@ public class TestExternalFeatures extends TestRerankBase {
 
     // Using nondefault store should still result in error with no efi
     query.remove("fl");
-    query.add("fl", "[fv store=fstore2]");
-    assertJQ("/query" + query.toQueryString(), "/error/msg=='Exception from createWeight for Feature [name=confidence, type=ValueFeature, id=0, params={value=${myconf}}] org.apache.solr.ltr.feature.impl.ValueFeature.ValueFeatureWeight requires efi parameter that was not passed in request.'");
-
+    query.add("fl", "fvalias:[fv store=fstore2]");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore:0.0'");
     // Adding efi in features section should make it work
     query.remove("fl");
     query.add("fl", "score,fvalias:[fv store=fstore2 efi.myconf=2.3]");

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestExternalValueFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestExternalValueFeatures.java
@@ -1,0 +1,94 @@
+package org.apache.solr.ltr.feature.impl;
+
+import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.TestRerankBase;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@SuppressCodecs({"Lucene3x", "Lucene41", "Lucene40", "Appending"})
+public class TestExternalValueFeatures extends TestRerankBase {
+
+  @BeforeClass
+  public static void before() throws Exception {
+    setuptest("solrconfig-ltr.xml", "schema-ltr.xml");
+
+    assertU(adoc("id", "1", "title", "w1", "description", "w1", "popularity",
+        "1"));
+    assertU(adoc("id", "2", "title", "w2", "description", "w2", "popularity",
+        "2"));
+    assertU(adoc("id", "3", "title", "w3", "description", "w3", "popularity",
+        "3"));
+    assertU(adoc("id", "4", "title", "w4", "description", "w4", "popularity",
+        "4"));
+    assertU(adoc("id", "5", "title", "w5", "description", "w5", "popularity",
+        "5"));
+    assertU(commit());
+
+    loadFeatures("external_features_for_sparse_processing.json");
+    loadModels("lambdamart_model_external_binary_features.json");
+  }
+
+  @AfterClass
+  public static void after() throws Exception {
+    aftertest();
+  }
+
+  @Test
+  public void efiFeatureProcessing_oneEfiMissing_shouldNotCalculateMissingFeature() throws Exception {
+    SolrQuery query = new SolrQuery();
+    query.setQuery("*:*");
+    query.add("fl", "*,score,features:[fv]");
+    query.add("rows", "3");
+    query.add("fl", "[fv]");
+    query
+        .add("rq", "{!ltr reRankDocs=3 model=external_model_binary_feature efi.user_device_tablet=1}");
+
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
+    assertJQ("/query" + query.toQueryString(),
+        "/response/docs/[0]/features=='user_device_tablet:1.0'");
+    assertJQ("/query" + query.toQueryString(),
+        "/response/docs/[0]/score==65.0");
+
+    System.out.println(restTestHarness.query("/query" + query.toQueryString()));
+  }
+
+  @Test
+  public void efiFeatureProcessing_allEfisMissing_shouldReturnZeroScore() throws Exception {
+    SolrQuery query = new SolrQuery();
+    query.setQuery("*:*");
+    query.add("fl", "*,score,features:[fv]");
+    query.add("rows", "3");
+
+    query.add("fl", "[fv]");
+    query
+        .add("rq", "{!ltr reRankDocs=3 model=external_model_binary_feature}");
+
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
+    assertJQ("/query" + query.toQueryString(),
+        "/response/docs/[0]/features==''");
+    assertJQ("/query" + query.toQueryString(),
+        "/response/docs/[0]/score==0.0");
+
+    System.out.println(restTestHarness.query("/query" + query.toQueryString()));
+  }
+}

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestValueFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestValueFeature.java
@@ -123,7 +123,7 @@ public class TestValueFeature extends TestRerankBase {
     // System.out.println(res);
 
     // No efi.val passed in
-    assertJQ("/query" + query.toQueryString(), "/responseHeader/status==400");
+    assertJQ("/query" + query.toQueryString(), "/responseHeader/status==0");
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestValueFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/impl/TestValueFeature.java
@@ -106,9 +106,9 @@ public class TestValueFeature extends TestRerankBase {
   }
 
   @Test
-  public void testValueFeature6() throws Exception {
+  public void testValueFeature6_implicitlyNotRequired_shouldReturnOkStatusCode() throws Exception {
     loadFeature("c5", ValueFeature.class.getCanonicalName(), "c5",
-        "{\"value\":\"${val5}\"}");
+        "{\"value\":\"${val6}\"}");
     loadModel("m5", RankSVMModel.class.getCanonicalName(), new String[] {"c5"},
         "c5", "{\"weights\":{\"c5\":1.0}}");
 
@@ -119,11 +119,41 @@ public class TestValueFeature extends TestRerankBase {
     query.add("wt", "json");
     query.add("rq", "{!ltr model=m5 reRankDocs=4}");
 
-    // String res = restTestHarness.query("/query" + query.toQueryString());
-    // System.out.println(res);
-
-    // No efi.val passed in
     assertJQ("/query" + query.toQueryString(), "/responseHeader/status==0");
+  }
+
+  @Test
+  public void testValueFeature6_explictlyNotRequired_shouldReturnOkStatusCode() throws Exception {
+    loadFeature("c7", ValueFeature.class.getCanonicalName(), "c7",
+        "{\"value\":\"${val7}\",\"required\":false}");
+    loadModel("m7", RankSVMModel.class.getCanonicalName(), new String[] {"c7"},
+        "c7", "{\"weights\":{\"c7\":1.0}}");
+
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("title:w1");
+    query.add("fl", "*, score,fvonly:[fvonly]");
+    query.add("rows", "4");
+    query.add("wt", "json");
+    query.add("rq", "{!ltr model=m7 reRankDocs=4}");
+
+    assertJQ("/query" + query.toQueryString(), "/responseHeader/status==0");
+  }
+
+  @Test
+  public void testValueFeature6_required_shouldReturn400StatusCode() throws Exception {
+    loadFeature("c8", ValueFeature.class.getCanonicalName(), "c8",
+        "{\"value\":\"${val8}\",\"required\":true}");
+    loadModel("m8", RankSVMModel.class.getCanonicalName(), new String[] {"c8"},
+        "c8", "{\"weights\":{\"c8\":1.0}}");
+
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("title:w1");
+    query.add("fl", "*, score,fvonly:[fvonly]");
+    query.add("rows", "4");
+    query.add("wt", "json");
+    query.add("rq", "{!ltr model=m8 reRankDocs=4}");
+
+    assertJQ("/query" + query.toQueryString(), "/responseHeader/status==400");
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestLTRQParserExplain.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestLTRQParserExplain.java
@@ -113,6 +113,66 @@ public class TestLTRQParserExplain extends TestRerankBase {
         "/debug/explain/9=='\n3.5116758 = RankSVMModel(name=6029760550880411648) model applied to features, sum of:\n  0.0 = prod of:\n    0.0 = weight on feature [would be cool to have the name :)]\n    1.0 = ValueFeature [name=title value=1.0]\n  0.2 = prod of:\n    0.1 = weight on feature [would be cool to have the name :)]\n    2.0 = ValueFeature [name=description value=2.0]\n  0.4 = prod of:\n    0.2 = weight on feature [would be cool to have the name :)]\n    2.0 = ValueFeature [name=keywords value=2.0]\n  0.09 = prod of:\n    0.3 = weight on feature [would be cool to have the name :)]\n    0.3 = normalized using MinMaxNormalizer [params {min=0.0f, max=10.0f}]\n      3.0 = ValueFeature [name=popularity value=3.0]\n  1.6 = prod of:\n    0.4 = weight on feature [would be cool to have the name :)]\n    4.0 = ValueFeature [name=text value=4.0]\n  0.6156155 = prod of:\n    0.1231231 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=queryIntentPerson value=5.0]\n  0.60606056 = prod of:\n    0.12121211 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=queryIntentCompany value=5.0]\n'}");
   }
 
+  @Test
+  public void SVMScoreExplain_missingEfiFeature_shouldReturnDefaultScore() throws Exception {
+    loadFeatures("features-ranksvm-efi.json");
+    loadModels("svm-model-efi.json");
+
+    SolrQuery query = new SolrQuery();
+    query.setQuery("title:bloomberg");
+    query.setParam("debugQuery", "on");
+    query.add("rows", "4");
+    query.add("rq", "{!ltr reRankDocs=4 model=svm-efi}");
+    query.add("fl", "*,score");
+    query.add("wt", "xml");
+
+    System.out.println(restTestHarness.query("/query" + query.toQueryString()));
+    query.remove("wt");
+    query.add("wt", "json");
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/debug/explain/7=='\n5.0 = RankSVMModel(name=svm-efi) model applied to features, sum of:\n  5.0 = prod of:\n    1.0 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=sampleConstant value=5.0]\n" +
+            "  0.0 = prod of:\n" +
+            "    2.0 = weight on feature [would be cool to have the name :)]\n" +
+            "    0.0 = The feature has no value\n'}");
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/debug/explain/9=='\n5.0 = RankSVMModel(name=svm-efi) model applied to features, sum of:\n  5.0 = prod of:\n    1.0 = weight on feature [would be cool to have the name :)]\n    5.0 = ValueFeature [name=sampleConstant value=5.0]\n" +
+            "  0.0 = prod of:\n" +
+            "    2.0 = weight on feature [would be cool to have the name :)]\n" +
+            "    0.0 = The feature has no value\n'}");
+  }
+
+  @Test
+  public void lambdaMARTScoreExplain_missingEfiFeature_shouldReturnDefaultScore() throws Exception {
+    loadFeatures("external_features_for_sparse_processing.json");
+    loadModels("lambdamart_model_external_binary_features.json");
+
+    SolrQuery query = new SolrQuery();
+    query.setQuery("title:bloomberg");
+    query.setParam("debugQuery", "on");
+    query.add("rows", "4");
+    query.add("rq", "{!ltr reRankDocs=4 model=external_model_binary_feature efi.user_device_tablet=1}");
+    query.add("fl", "*,score");
+    query.add("wt", "xml");
+
+    System.out.println(restTestHarness.query("/query" + query.toQueryString()));
+    query.remove("wt");
+    query.add("wt", "json");
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/debug/explain/7=='\n" +
+            "65.0 = LambdaMARTModel(name=external_model_binary_feature) model applied to features, sum of:\n" +
+            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.500001, Go Left | val: 0.0\n" +
+            "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.500001, Go Right | val: 65.0\n'}");
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/debug/explain/9=='\n" +
+            "65.0 = LambdaMARTModel(name=external_model_binary_feature) model applied to features, sum of:\n" +
+            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.500001, Go Left | val: 0.0\n" +
+            "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.500001, Go Right | val: 65.0\n'}");
+  }
+
   // @Test
   // public void checkfq() throws Exception {
   //


### PR DESCRIPTION
The change affect mainly the ValueFeature.
In the case we have a null value, the scorer is not returned.
This should skip at all the feature calculus and the storage in the cache.
For the SolrFeature the behaviour remains invariated ( an exception is raised)