### PR TITLE
More towards pluggable Feature classes.

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/FeatureStore.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/FeatureStore.java
@@ -52,12 +52,7 @@ public class FeatureStore {
   public List<Object> featuresAsManagedResources() {
     final List<Object> features = new ArrayList<Object>(store.size());
     for (final Feature f : store.values()) {
-      final Map<String,Object> o = new LinkedHashMap<>(4, 1.0f);
-      o.put("name", f.getName());
-      o.put("type", f.getClass().getCanonicalName());
-      o.put("store", name);
-      o.put("params", f.getParams());
-      features.add(o);
+      features.add(f.toMap(name));
     }
     return features;
   }

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldLengthFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldLengthFeature.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature.impl;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.lucene.index.IndexableField;
@@ -42,6 +43,13 @@ public class FieldLengthFeature extends Feature {
 
   public void setField(String field) {
     this.field = field;
+  }
+
+  @Override
+  protected LinkedHashMap<String,Object> paramsToMap() {
+    final LinkedHashMap<String,Object> params = new LinkedHashMap<>(1, 1.0f);
+    params.put("field", field);
+    return params;
   }
 
   /** Cache of decoded bytes. */

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldValueFeature.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature.impl;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -46,6 +47,13 @@ public class FieldValueFeature extends Feature {
   public void setField(String field) {
     this.field = field;
     fieldAsSet = Sets.newHashSet(field);
+  }
+
+  @Override
+  protected LinkedHashMap<String,Object> paramsToMap() {
+    final LinkedHashMap<String,Object> params = new LinkedHashMap<>(1, 1.0f);
+    params.put("field", field);
+    return params;
   }
 
   public FieldValueFeature() {

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/OriginalScoreFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/OriginalScoreFeature.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature.impl;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.lucene.index.LeafReaderContext;
@@ -30,6 +31,11 @@ import org.apache.solr.ltr.util.CommonLTRParams;
 import org.apache.solr.request.SolrQueryRequest;
 
 public class OriginalScoreFeature extends Feature {
+
+  @Override
+  protected LinkedHashMap<String,Object> paramsToMap() {
+    return null;
+  }
 
   @Override
   public OriginalScoreWeight createWeight(IndexSearcher searcher,

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/SolrFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/SolrFeature.java
@@ -18,6 +18,7 @@ package org.apache.solr.ltr.feature.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +70,21 @@ public class SolrFeature extends Feature {
 
   public void setFq(List<String> fq) {
     this.fq = fq;
+  }
+
+  @Override
+  protected LinkedHashMap<String,Object> paramsToMap() {
+    final LinkedHashMap<String,Object> params = new LinkedHashMap<>(3, 1.0f);
+    if (df != null) {
+      params.put("df", df);
+    }
+    if (q != null) {
+      params.put("q", q);
+    }
+    if (fq != null) {
+      params.put("fq", fq);
+    }
+    return params;
   }
 
   @Override
@@ -217,14 +233,12 @@ public class SolrFeature extends Feature {
     }
 
     public class SolrFeatureScorer extends FeatureScorer {
-      Scorer solrScorer;
-      String q;
-      DocIdSetIterator itr;
+      final private Scorer solrScorer;
+      final private DocIdSetIterator itr;
 
       public SolrFeatureScorer(FeatureWeight weight, Scorer solrScorer,
           DocIdSetIterator filterIterator) {
         super(weight);
-        q = (String) getParams().get(CommonParams.Q);
         this.solrScorer = solrScorer;
         itr = new SolrFeatureScorerIterator(filterIterator,
             solrScorer.iterator());
@@ -247,8 +261,8 @@ public class SolrFeature extends Feature {
 
       private class SolrFeatureScorerIterator extends DocIdSetIterator {
 
-        DocIdSetIterator filterIterator;
-        DocIdSetIterator scorerFilter;
+        final private DocIdSetIterator filterIterator;
+        final private DocIdSetIterator scorerFilter;
         int docID;
 
         SolrFeatureScorerIterator(DocIdSetIterator filterIterator,
@@ -287,13 +301,11 @@ public class SolrFeature extends Feature {
     }
 
     public class SolrFeatureFilterOnlyScorer extends FeatureScorer {
-      String fq;
-      DocIdSetIterator itr;
+      final private DocIdSetIterator itr;
 
       public SolrFeatureFilterOnlyScorer(FeatureWeight weight,
           DocIdSetIterator iterator) {
         super(weight);
-        fq = (String) getParams().get(CommonParams.FQ);
         itr = iterator;
       }
 

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature.impl;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.lucene.index.LeafReaderContext;
@@ -37,7 +38,7 @@ public class ValueFeature extends Feature {
   private String configValueStr = null;
 
   private Object value = null;
-  private boolean required = false;
+  private Boolean required = null;
 
   public Object getValue() {
     return value;
@@ -61,11 +62,21 @@ public class ValueFeature extends Feature {
   }
 
   public boolean isRequired() {
-    return required;
+    return Boolean.TRUE.equals(required);
   }
 
   public void setRequired(boolean required) {
     this.required = required;
+  }
+
+  @Override
+  protected LinkedHashMap<String,Object> paramsToMap() {
+    final LinkedHashMap<String,Object> params = new LinkedHashMap<>(2, 1.0f);
+    params.put("value", value);
+    if (required != null) {
+      params.put("required", required);
+    }
+    return params;
   }
 
   public ValueFeature() {}
@@ -103,7 +114,7 @@ public class ValueFeature extends Feature {
         final String expandedValue = macroExpander.expand(configValueStr);
         if (expandedValue != null) {
           featureValue = Float.parseFloat(expandedValue);
-        } else if (required) {
+        } else if (isRequired()) {
           throw new FeatureException(this.getClass().getSimpleName() + " requires efi parameter that was not passed in request.");
         } else {
           featureValue=null;

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/Normalizer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/Normalizer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.ltr.feature.norm;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.lucene.search.Explanation;
@@ -37,7 +37,7 @@ public abstract class Normalizer {
 
   public abstract float normalize(float value);
 
-  protected abstract Map<String,Object> paramsToMap();
+  protected abstract LinkedHashMap<String,Object> paramsToMap();
 
   public Explanation explain(Explanation explain) {
     final float normalized = normalize(explain.getValue());
@@ -68,12 +68,12 @@ public abstract class Normalizer {
         type, params);
   }
 
-  public Map<String,Object> toMap() {
-    final Map<String,Object> normalizer = new HashMap<>(2, 1.0f);
+  public LinkedHashMap<String,Object> toMap() {
+    final LinkedHashMap<String,Object> normalizer = new LinkedHashMap<>(2, 1.0f);
 
     normalizer.put(TYPE_KEY, getClass().getCanonicalName());
 
-    final Map<String,Object> params = paramsToMap();
+    final LinkedHashMap<String,Object> params = paramsToMap();
     if (params != null) {
       normalizer.put(PARAMS_KEY, params);
     }

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/impl/IdentityNormalizer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/impl/IdentityNormalizer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.ltr.feature.norm.impl;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import org.apache.solr.ltr.feature.norm.Normalizer;
 
@@ -34,7 +34,7 @@ public class IdentityNormalizer extends Normalizer {
   }
 
   @Override
-  protected Map<String,Object> paramsToMap() {
+  protected LinkedHashMap<String,Object> paramsToMap() {
     return null;
   }
 

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/impl/MinMaxNormalizer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/impl/MinMaxNormalizer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.ltr.feature.norm.impl;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.solr.ltr.feature.norm.Normalizer;
@@ -65,8 +65,8 @@ public class MinMaxNormalizer extends Normalizer {
   }
 
   @Override
-  protected Map<String,Object> paramsToMap() {
-    final Map<String,Object> params = new HashMap<>(2, 1.0f);
+  protected LinkedHashMap<String,Object> paramsToMap() {
+    final LinkedHashMap<String,Object> params = new LinkedHashMap<>(2, 1.0f);
     params.put("min", min);
     params.put("max", max);
     return params;

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/impl/StandardNormalizer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/norm/impl/StandardNormalizer.java
@@ -16,8 +16,7 @@
  */
 package org.apache.solr.ltr.feature.norm.impl;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import org.apache.solr.ltr.feature.norm.Normalizer;
 
@@ -56,8 +55,8 @@ public class StandardNormalizer extends Normalizer {
   }
 
   @Override
-  protected Map<String,Object> paramsToMap() {
-    final Map<String,Object> params = new HashMap<>(2, 1.0f);
+  protected LinkedHashMap<String,Object> paramsToMap() {
+    final LinkedHashMap<String,Object> params = new LinkedHashMap<>(2, 1.0f);
     params.put("avg", avg);
     params.put("std", std);
     return params;

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/Feature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/Feature.java
@@ -88,7 +88,7 @@ public abstract class Feature extends Query implements Cloneable {
     final StringBuilder sb = new StringBuilder(64); // default initialCapacity of 16 won't be enough
     sb.append(getClass().getSimpleName());
     sb.append(" [name=").append(name);
-    final Map<String,Object> params = paramsToMap();
+    final LinkedHashMap<String,Object> params = paramsToMap();
     if (params != null) {
       sb.append(", params=").append(params);
     }

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/Feature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/Feature.java
@@ -18,6 +18,7 @@ package org.apache.solr.ltr.ranking;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,7 +44,9 @@ public abstract class Feature extends Query implements Cloneable {
   protected String name;
   protected Normalizer norm = IdentityNormalizer.INSTANCE;
   protected int id;
-  protected NamedParams params = NamedParams.EMPTY;
+
+  @Deprecated
+  private NamedParams params = NamedParams.EMPTY;
 
 
   /**
@@ -82,9 +85,15 @@ public abstract class Feature extends Query implements Cloneable {
 
   @Override
   public String toString(String field) {
-    return getClass().getSimpleName() 
-        + " [name=" + name 
-        + ", params=" + params + "]";
+    final StringBuilder sb = new StringBuilder(64); // default initialCapacity of 16 won't be enough
+    sb.append(getClass().getSimpleName());
+    sb.append(" [name=").append(name);
+    final Map<String,Object> params = paramsToMap();
+    if (params != null) {
+      sb.append(", params=").append(params);
+    }
+    sb.append(']');
+    return sb.toString();
   }
 
   public abstract FeatureWeight createWeight(IndexSearcher searcher,
@@ -147,16 +156,20 @@ public abstract class Feature extends Query implements Cloneable {
     return id;
   }
 
-  /**
-   * @return the params
-   */
-  public NamedParams getParams() {
-    return params;
-  }
+  protected abstract LinkedHashMap<String,Object> paramsToMap();
 
   public void setNorm(Normalizer norm) {
     this.norm = norm;
 
+  }
+
+  public LinkedHashMap<String,Object> toMap(String storeName) {
+    final LinkedHashMap<String,Object> o = new LinkedHashMap<>(4, 1.0f);
+    o.put("name", name);
+    o.put("type", getClass().getCanonicalName());
+    o.put("store", storeName);
+    o.put("params", paramsToMap());
+    return o;
   }
   
   
@@ -196,10 +209,6 @@ public abstract class Feature extends Query implements Cloneable {
 
     public Normalizer getNorm() {
       return Feature.this.norm;
-    }
-
-    public NamedParams getParams() {
-      return Feature.this.params;
     }
 
     public int getId() {

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureStore.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureStore.java
@@ -58,15 +58,17 @@ public class TestFeatureStore extends TestRerankBase {
     final FeatureStore fs = fstore.getFeatureStore("fstore-testFeature2");
     for (int i = 0; i < 5; i++) {
 
-      fstore.addFeature("c" + (float) i, ValueFeature.class.getCanonicalName(),
+      fstore.addFeature("c" + i, ValueFeature.class.getCanonicalName(),
           "fstore-testFeature2", new NamedParams().add("value", i));
 
     }
 
-    for (float i = 0; i < 5; i++) {
+    for (int i = 0; i < 5; i++) {
       final Feature f = fs.get("c" + i);
       assertEquals("c" + i, f.getName());
-      assertEquals(i, f.getParams().getFloat("value"), 0.0001);
+      assertTrue(f instanceof ValueFeature);
+      final ValueFeature vf = (ValueFeature)f;
+      assertEquals(i, vf.getValue());
     }
   }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestModelQuery.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestModelQuery.java
@@ -19,8 +19,8 @@ package org.apache.solr.ltr.ranking;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -75,7 +75,7 @@ public class TestModelQuery extends LuceneTestCase {
     for (final int i : featureIds) {
       final ValueFeature f = new ValueFeature();
       f.name = "f" + i;
-      f.params = new NamedParams().add("value", i);
+      f.setValue(i);
       f.id = i;
       f.norm = new Normalizer() {
 
@@ -85,7 +85,7 @@ public class TestModelQuery extends LuceneTestCase {
         }
 
         @Override
-        protected Map<String,Object> paramsToMap() {
+        protected LinkedHashMap<String,Object> paramsToMap() {
           return null;
         }
       };

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestReRankingPipeline.java
@@ -66,7 +66,7 @@ public class TestReRankingPipeline extends LuceneTestCase {
     for (final int i : featureIds) {
       final FieldValueFeature f = new FieldValueFeature();
       f.name = "f" + i;
-      f.params = new NamedParams().add("field", field);
+      f.setField(field);
       features.add(f);
     }
     return features;


### PR DESCRIPTION
* Remove unused SolrFeature class members, make others private and final.
* Normalizer classes now use LinkedHashMap (instead of HashMap or Map) to preserve order of elements.
* Almost (but not quite yet) removed all Feature.params use.