### PR TITLE
remove Feature.init (towards fully pluggable Feature classes)

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldLengthFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldLengthFeature.java
@@ -28,8 +28,6 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.SmallFloat;
 import org.apache.solr.ltr.ranking.Feature;
-import org.apache.solr.ltr.util.CommonLTRParams;
-import org.apache.solr.ltr.util.FeatureException;
 import org.apache.solr.request.SolrQueryRequest;
 
 public class FieldLengthFeature extends Feature {
@@ -73,8 +71,8 @@ public class FieldLengthFeature extends Feature {
     // positive above 127
   }
 
-  public FieldLengthFeature(String name) {
-    super(name);
+  public FieldLengthFeature(String name, Map<String,Object> params) {
+    super(name, params);
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/FieldValueFeature.java
@@ -28,8 +28,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.solr.ltr.ranking.Feature;
-import org.apache.solr.ltr.util.CommonLTRParams;
-import org.apache.solr.ltr.util.FeatureException;
 import org.apache.solr.request.SolrQueryRequest;
 
 import com.google.common.collect.Sets;
@@ -55,8 +53,8 @@ public class FieldValueFeature extends Feature {
     return params;
   }
 
-  public FieldValueFeature(String name) {
-    super(name);
+  public FieldValueFeature(String name, Map<String,Object> params) {
+    super(name, params);
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/OriginalScoreFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/OriginalScoreFeature.java
@@ -32,8 +32,8 @@ import org.apache.solr.request.SolrQueryRequest;
 
 public class OriginalScoreFeature extends Feature {
 
-  public OriginalScoreFeature(String name) {
-    super(name);
+  public OriginalScoreFeature(String name, Map<String,Object> params) {
+    super(name, params);
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/SolrFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/SolrFeature.java
@@ -41,7 +41,6 @@ import org.apache.solr.search.QParser;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.SolrIndexSearcher.ProcessedFilter;
 import org.apache.solr.search.SyntaxError;
-import org.apache.solr.ltr.util.FeatureException;
 
 public class SolrFeature extends Feature {
 
@@ -73,8 +72,8 @@ public class SolrFeature extends Feature {
     this.fq = fq;
   }
 
-  public SolrFeature(String name) {
-    super(name);
+  public SolrFeature(String name, Map<String,Object> params) {
+    super(name, params);
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/feature/impl/ValueFeature.java
@@ -79,8 +79,8 @@ public class ValueFeature extends Feature {
     return params;
   }
 
-  public ValueFeature(String name) {
-    super(name);
+  public ValueFeature(String name, Map<String,Object> params) {
+    super(name, params);
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/Feature.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/Feature.java
@@ -29,11 +29,11 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
+import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.ltr.util.CommonLTRParams;
-import org.apache.solr.ltr.util.FeatureException;
-import org.apache.solr.ltr.util.LTRUtils;
 import org.apache.solr.ltr.util.MacroExpander;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.util.SolrPluginUtils;
 
 /**
  * A 'recipe' for computing a feature
@@ -41,23 +41,26 @@ import org.apache.solr.request.SolrQueryRequest;
 public abstract class Feature extends Query {
 
   final protected String name;
-  protected int id;
+  private int id;
 
-  @Deprecated
-  private Map<String,Object> params = LTRUtils.EMPTY_MAP;
+  final private Map<String,Object> params;
 
-
-  /**
-   * @param params
-   *          Custom parameters that the feature may use
-   */
-  final public void init(Map<String,Object> params)
-      throws FeatureException {
-    this.params = params;
+  public static Feature getInstance(SolrResourceLoader solrResourceLoader,
+      String type, String name, int id, Map<String,Object> params) {
+    final Feature f = solrResourceLoader.newInstance(
+        type,
+        Feature.class,
+        new String[0], // no sub packages
+        new Class[] { String.class, Map.class },
+        new Object[] { name, params });
+    f.setId(id);
+    SolrPluginUtils.invokeSetters(f, params.entrySet());
+    return f;
   }
 
-  public Feature(String name) {
+  public Feature(String name, Map<String,Object> params) {
     this.name = name;
+    this.params = params;
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/rest/ManagedFeatureStore.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/rest/ManagedFeatureStore.java
@@ -35,7 +35,6 @@ import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.rest.BaseSolrResource;
 import org.apache.solr.rest.ManagedResource;
 import org.apache.solr.rest.ManagedResourceStorage.StorageIO;
-import org.apache.solr.util.SolrPluginUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,17 +126,8 @@ public class ManagedFeatureStore extends ManagedResource implements
   private Feature createFeature(String name, String type, Map<String,Object> params,
       int id) throws FeatureException {
     try {
-      final Feature f = solrResourceLoader.newInstance(
-          type,
-          Feature.class,
-          new String[0], // no sub packages
-          new Class[] { String.class },
-          new Object[] { name });
-      f.init(params);
-      f.setId(id);
-      SolrPluginUtils.invokeSetters(f, params.entrySet());
-      return f;
-
+      return Feature.getInstance(solrResourceLoader,
+          type, name, id, params);
     } catch (final Exception e) {
       throw new FeatureException(e.getMessage(), e);
     }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
@@ -37,6 +37,7 @@ import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.ContentStreamBase;
+import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.ltr.feature.LTRScoringAlgorithm;
 import org.apache.solr.ltr.feature.impl.ValueFeature;
 import org.apache.solr.ltr.feature.impl.ValueFeature.ValueFeatureWeight;
@@ -60,6 +61,8 @@ import org.slf4j.LoggerFactory;
 public class TestRerankBase extends RestTestBase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final SolrResourceLoader solrResourceLoader = new SolrResourceLoader();
   
   protected static File tmpSolrHome;
   protected static File tmpConfDir;
@@ -328,12 +331,11 @@ public class TestRerankBase extends RestTestBase {
     final List<Feature> features = new ArrayList<>();
     int pos = 0;
     for (final String name : names) {
-      final ValueFeature f = new ValueFeature(name);
       final Map<String,Object> params = new HashMap<String,Object>();
       params.put("value", 10);
-      f.init(params);
-      f.setValue(10);
-      f.setId(pos);
+      final Feature f = Feature.getInstance(solrResourceLoader,
+          ValueFeature.class.getCanonicalName(),
+          name, pos, params);
       features.add(f);
       ++pos;
     }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestModelQuery.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestModelQuery.java
@@ -42,16 +42,18 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
+import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.ltr.feature.LTRScoringAlgorithm;
 import org.apache.solr.ltr.feature.impl.ValueFeature;
 import org.apache.solr.ltr.feature.norm.Normalizer;
 import org.apache.solr.ltr.feature.norm.impl.IdentityNormalizer;
-import org.apache.solr.ltr.util.FeatureException;
 import org.apache.solr.ltr.util.ModelException;
 import org.junit.Test;
 
 @SuppressCodecs("Lucene3x")
 public class TestModelQuery extends LuceneTestCase {
+
+  final private static SolrResourceLoader solrResourceLoader = new SolrResourceLoader();
 
   private IndexSearcher getSearcher(IndexReader r) {
     final IndexSearcher searcher = newSearcher(r, false, false);
@@ -61,16 +63,11 @@ public class TestModelQuery extends LuceneTestCase {
   private static List<Feature> makeFeatures(int[] featureIds) {
     final List<Feature> features = new ArrayList<>();
     for (final int i : featureIds) {
-      final ValueFeature f = new ValueFeature("f" + i);
       Map<String,Object> params = new HashMap<String,Object>();
       params.put("value", i);
-      try {
-        f.init(params);
-        f.setValue(i);
-        f.setId(i);
-      } catch (final FeatureException e) {
-        e.printStackTrace();
-      }
+      final Feature f = Feature.getInstance(solrResourceLoader,
+          ValueFeature.class.getCanonicalName(),
+          "f" + i, i, params);
       features.add(f);
     }
     return features;
@@ -79,9 +76,11 @@ public class TestModelQuery extends LuceneTestCase {
   private static List<Feature> makeFilterFeatures(int[] featureIds) {
     final List<Feature> features = new ArrayList<>();
     for (final int i : featureIds) {
-      final ValueFeature f = new ValueFeature("f" + i);
-      f.setValue(i);
-      f.id = i;
+      Map<String,Object> params = new HashMap<String,Object>();
+      params.put("value", i);
+      final Feature f = Feature.getInstance(solrResourceLoader,
+          ValueFeature.class.getCanonicalName(),
+          "f" + i, i, params);
       features.add(f);
     }
     return features;

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/ranking/TestReRankingPipeline.java
@@ -42,6 +42,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
+import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.ltr.feature.LTRScoringAlgorithm;
 import org.apache.solr.ltr.feature.impl.FieldValueFeature;
 import org.apache.solr.ltr.feature.norm.Normalizer;
@@ -58,6 +59,8 @@ public class TestReRankingPipeline extends LuceneTestCase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   
+  private static final SolrResourceLoader solrResourceLoader = new SolrResourceLoader();
+
   private IndexSearcher getSearcher(IndexReader r) {
     final IndexSearcher searcher = newSearcher(r);
 
@@ -68,8 +71,11 @@ public class TestReRankingPipeline extends LuceneTestCase {
       String field) {
     final List<Feature> features = new ArrayList<>();
     for (final int i : featureIds) {
-      final FieldValueFeature f = new FieldValueFeature("f" + i);
-      f.setField(field);
+      final Map<String,Object> params = new HashMap<String,Object>();
+      params.put("field", field);
+      final Feature f = Feature.getInstance(solrResourceLoader,
+          FieldValueFeature.class.getCanonicalName(),
+          "f" + i, i, params);
       features.add(f);
     }
     return features;


### PR DESCRIPTION
* now keeping Feature.params field (as private and final) so that deriving classes need not supply hashCode() and equals() methods
* removed some no-longer-used constants in CommonLTRParams