### PR TITLE
move LTRFeatureLoggerTransformerFactory to solr.response.transform

### DIFF
--- a/solr/contrib/ltr/README.md
+++ b/solr/contrib/ltr/README.md
@@ -99,7 +99,7 @@ BONUS: Train an actual machine learning model
   In order to get the feature vector you will have to
   specify that you want the field (e.g., fl="*,[features])  -->
 
-  <transformer name="features" class="org.apache.solr.ltr.ranking.LTRFeatureLoggerTransformerFactory" />
+  <transformer name="features" class="org.apache.solr.response.transform.LTRFeatureLoggerTransformerFactory" />
 
   <query>
     ...

--- a/solr/contrib/ltr/example/solrconfig.xml
+++ b/solr/contrib/ltr/example/solrconfig.xml
@@ -866,7 +866,7 @@
   will add the features as an extra field in the response. The name of the field we will be the the name of the
   transformer enclosed between brackets (in this case [features]). In order to get the feature vector you will have to
   specify that you want the field (e.g., fl="*,[features])  -->
-  <transformer name="features" class="org.apache.solr.ltr.ranking.LTRFeatureLoggerTransformerFactory" />
+  <transformer name="features" class="org.apache.solr.response.transform.LTRFeatureLoggerTransformerFactory" />
 
 
   <!-- A request handler that returns indented JSON by default -->

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/LTRQParserPlugin.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/LTRQParserPlugin.java
@@ -37,6 +37,7 @@ import org.apache.solr.ltr.rest.ManagedModelStore;
 import org.apache.solr.ltr.util.CommonLTRParams;
 import org.apache.solr.ltr.util.LTRUtils;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.transform.LTRFeatureLoggerTransformerFactory;
 import org.apache.solr.rest.ManagedResource;
 import org.apache.solr.rest.ManagedResourceObserver;
 import org.apache.solr.search.QParser;

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ranking/ModelQuery.java
@@ -376,6 +376,10 @@ public class ModelQuery extends Query {
       } 
     }
 
+    public FeatureInfo[] getFeaturesInfo(){
+      return featuresInfo;
+    }
+
     /**
      * Goes through all the stored feature values, and calculates the normalized
      * values for all the features that will be used for scoring.

--- a/solr/contrib/ltr/src/java/org/apache/solr/response/package-info.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/response/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+/** 
+ * API and implementations of {@link org.apache.solr.response.QueryResponseWriter} for formatting Solr request responses
+ */
+package org.apache.solr.response;
+
+

--- a/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.solr.ltr.ranking;
+package org.apache.solr.response.transform;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,6 +31,8 @@ import org.apache.solr.ltr.feature.FeatureStore;
 import org.apache.solr.ltr.feature.OriginalScoreFeature;
 import org.apache.solr.ltr.log.FeatureLogger;
 import org.apache.solr.ltr.log.LoggingModel;
+import org.apache.solr.ltr.ranking.LTRQParserPlugin;
+import org.apache.solr.ltr.ranking.ModelQuery;
 import org.apache.solr.ltr.ranking.ModelQuery.FeatureInfo;
 import org.apache.solr.ltr.ranking.ModelQuery.ModelWeight;
 import org.apache.solr.ltr.ranking.ModelQuery.ModelWeight.ModelScorer;
@@ -212,7 +214,7 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
           }
           r.score();
           doc.addField(name,
-              featureLogger.makeFeatureVector(modelWeight.featuresInfo));
+              featureLogger.makeFeatureVector(modelWeight.getFeaturesInfo()));
         }
       } else {
         doc.addField(name, fv);

--- a/solr/contrib/ltr/src/java/org/apache/solr/response/transform/package-info.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/response/transform/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+/** 
+ * APIs and implementations of {@link org.apache.solr.response.transform.DocTransformer} for modifying documents in Solr request responses
+ */
+package org.apache.solr.response.transform;
+
+

--- a/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr.xml
+++ b/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr.xml
@@ -36,7 +36,7 @@
   enclosed between brackets (in this case [fv]). In order to get the feature
   vector you will have to specify that you want the field (e.g., fl="*,[fv]) -->
  <transformer name="fv"
-  class="org.apache.solr.ltr.ranking.LTRFeatureLoggerTransformerFactory" />
+  class="org.apache.solr.response.transform.LTRFeatureLoggerTransformerFactory" />
 
  <updateHandler class="solr.DirectUpdateHandler2">
   <autoCommit>


### PR DESCRIPTION
(this is where the other transformers live and so when in the future solr/contrib/ltr graduates to solr/core then users therefore need not update their configs)