### PR TITLE
rename 'tree' to 'root' in LambdaMARTModel.RegressionTree

### DIFF
--- a/solr/contrib/ltr/README.md
+++ b/solr/contrib/ltr/README.md
@@ -257,7 +257,7 @@ libSVM model format to the format specified above.
         "trees": [
             {
                 "weight" : 1,
-                "tree": {
+                "root": {
                     "feature": "userTextTitleMatch",
                     "threshold": 0.5,
                     "left" : {
@@ -277,7 +277,7 @@ libSVM model format to the format specified above.
             },
             {
                 "weight" : 2,
-                "tree": {
+                "root": {
                     "value" : -10
                 }
             }

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/model/LambdaMARTModel.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/model/LambdaMARTModel.java
@@ -192,7 +192,7 @@ public class LambdaMARTModel extends LTRScoringModel {
       this.weight = new Float(weight);
     }
 
-    public void setTree(Object root) {
+    public void setRoot(Object root) {
       this.root = createRegressionTreeNode((Map<String,Object>)root);
     }
 

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model.json
@@ -9,7 +9,7 @@
         "trees": [
             {
                 "weight" : "1f",
-                "tree": {
+                "root": {
                     "feature": "matchedTitle",
                     "threshold": "0.5f",
                     "left" : {
@@ -29,7 +29,7 @@
             },
             {
                 "weight" : "2f",
-                "tree": {
+                "root": {
                     "value" : "-10"
                 }
             }

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_external_binary_features.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_external_binary_features.json
@@ -9,7 +9,7 @@
     "trees": [
       {
         "weight" : "1f",
-        "tree": {
+        "root": {
           "feature": "user_device_smartphone",
           "threshold": "0.5f",
           "left" : {
@@ -22,7 +22,7 @@
         }},
       {
         "weight" : "1f",
-        "tree": {
+        "root": {
           "feature": "user_device_tablet",
           "threshold": "0.5f",
           "left" : {

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_feature.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_feature.json
@@ -9,7 +9,7 @@
         "trees": [
             {
                 "weight" : "1f",
-                "tree": {
+                "root": {
                     "threshold": "0.5f",
                     "left" : {
                         "value" : "-100"

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_features.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_features.json
@@ -5,7 +5,7 @@
         "trees": [
             {
                 "weight" : "2f",
-                "tree": {
+                "root": {
                     "value" : "-10"
                 }
             }

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_left.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_left.json
@@ -9,7 +9,7 @@
         "trees": [
             {
                 "weight" : "1f",
-                "tree": {
+                "root": {
                     "feature": "matchedTitle",
                     "threshold": "0.5f",
                     "right": {

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_right.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_right.json
@@ -9,7 +9,7 @@
         "trees": [
             {
                 "weight" : "1f",
-                "tree": {
+                "root": {
                     "feature": "matchedTitle",
                     "threshold": "0.5f",
                     "left" : {

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_threshold.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_threshold.json
@@ -9,7 +9,7 @@
         "trees": [
             {
                 "weight" : "1f",
-                "tree": {
+                "root": {
                     "feature": "matchedTitle",
                     "left" : {
                         "value" : "-100"

--- a/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_weight.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/lambdamart_model_no_weight.json
@@ -8,7 +8,7 @@
     "params":{
         "trees": [
             {
-                "tree": {
+                "root": {
                     "feature": "matchedTitle",
                     "threshold": "0.5f",
                     "left" : {

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
@@ -184,7 +184,7 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
         LambdaMARTModel.class.getCanonicalName(),
         new String[] {"nomatchfeature4"},
         "noMatchFeaturesStore",
-        "{\"trees\":[{\"weight\":\"1f\", \"tree\":{\"feature\": \"matchedTitle\",\"threshold\": \"0.5f\",\"left\":{\"value\" : \"-10\"},\"right\":{\"value\" : \"9\"}}}]}");
+        "{\"trees\":[{\"weight\":\"1f\", \"root\":{\"feature\": \"matchedTitle\",\"threshold\": \"0.5f\",\"left\":{\"value\" : \"-10\"},\"right\":{\"value\" : \"9\"}}}]}");
 
     final SolrQuery query = new SolrQuery();
     query.setQuery("*:*");


### PR DESCRIPTION
(to match variable name and to avoid confusion with the LambdaMARTModel 'trees' field)