### PR TITLE
factor out SolrQueryRequestContextUtils class

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/SolrQueryRequestContextUtils.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/SolrQueryRequestContextUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.ltr;
+
+import org.apache.solr.request.SolrQueryRequest;
+
+public class SolrQueryRequestContextUtils {
+
+  /** key prefix to reduce possibility of clash with other code's key choices **/
+  private static final String LTR_PREFIX = "ltr.";
+
+  /** key of the feature logger in the request context **/
+  private static final String FEATURE_LOGGER = LTR_PREFIX + "feature_logger";
+
+  /** key of the model query in the request context **/
+  private static final String MODEL_QUERY = LTR_PREFIX + "model_query";
+
+  /** key of the useFvCache flag in the request context **/
+  private static final String USE_FV_CACHE = LTR_PREFIX + "fvCache";
+
+  /** key of the feature vector store name in the request context **/
+  private static final String STORE = LTR_PREFIX + "store";
+
+  /** feature logger accessors **/
+
+  public static void setFeatureLogger(SolrQueryRequest req, FeatureLogger<?> featureLogger) {
+    req.getContext().put(FEATURE_LOGGER, featureLogger);
+  }
+
+  public static FeatureLogger<?> getFeatureLogger(SolrQueryRequest req) {
+    return (FeatureLogger<?>) req.getContext().get(FEATURE_LOGGER);
+  }
+
+  /** model query accessors **/
+
+  public static void setModelQuery(SolrQueryRequest req, ModelQuery modelQuery) {
+    req.getContext().put(MODEL_QUERY, modelQuery);
+  }
+
+  public static ModelQuery getModelQuery(SolrQueryRequest req) {
+    return (ModelQuery) req.getContext().get(MODEL_QUERY);
+  }
+
+  /** useFvCache flag accessors **/
+
+  public static void setUseFvCache(SolrQueryRequest req) {
+    req.getContext().put(USE_FV_CACHE, Boolean.TRUE);
+  }
+
+  public static void clearUseFvCache(SolrQueryRequest req) {
+    req.getContext().put(USE_FV_CACHE, Boolean.FALSE);
+  }
+
+  public static boolean useFvCache(SolrQueryRequest req) {
+    return Boolean.TRUE.equals(req.getContext().get(USE_FV_CACHE));
+  }
+
+  /** feature vector store name accessors **/
+
+  public static void setFvStoreName(SolrQueryRequest req, String fvStoreName) {
+    req.getContext().put(STORE, fvStoreName);
+  }
+
+  public static String getFvStoreName(SolrQueryRequest req) {
+    return (String) req.getContext().get(STORE);
+  }
+
+}
+

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/SolrQueryRequestContextUtils.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/SolrQueryRequestContextUtils.java
@@ -29,8 +29,8 @@ public class SolrQueryRequestContextUtils {
   /** key of the model query in the request context **/
   private static final String MODEL_QUERY = LTR_PREFIX + "model_query";
 
-  /** key of the useFvCache flag in the request context **/
-  private static final String USE_FV_CACHE = LTR_PREFIX + "fvCache";
+  /** key of the isExtractingFeatures flag in the request context **/
+  private static final String IS_EXTRACTING_FEATURES = LTR_PREFIX + "isExtractingFeatures";
 
   /** key of the feature vector store name in the request context **/
   private static final String STORE = LTR_PREFIX + "store";
@@ -55,18 +55,18 @@ public class SolrQueryRequestContextUtils {
     return (ModelQuery) req.getContext().get(MODEL_QUERY);
   }
 
-  /** useFvCache flag accessors **/
+  /** isExtractingFeatures flag accessors **/
 
-  public static void setUseFvCache(SolrQueryRequest req) {
-    req.getContext().put(USE_FV_CACHE, Boolean.TRUE);
+  public static void setIsExtractingFeatures(SolrQueryRequest req) {
+    req.getContext().put(IS_EXTRACTING_FEATURES, Boolean.TRUE);
   }
 
-  public static void clearUseFvCache(SolrQueryRequest req) {
-    req.getContext().put(USE_FV_CACHE, Boolean.FALSE);
+  public static void clearIsExtractingFeatures(SolrQueryRequest req) {
+    req.getContext().put(IS_EXTRACTING_FEATURES, Boolean.FALSE);
   }
 
-  public static boolean useFvCache(SolrQueryRequest req) {
-    return Boolean.TRUE.equals(req.getContext().get(USE_FV_CACHE));
+  public static boolean isExtractingFeatures(SolrQueryRequest req) {
+    return Boolean.TRUE.equals(req.getContext().get(IS_EXTRACTING_FEATURES));
   }
 
   /** feature vector store name accessors **/

--- a/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
@@ -85,7 +85,7 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
       SolrQueryRequest req) {
 
     // Hint to enable feature vector cache since we are requesting features
-    SolrQueryRequestContextUtils.setUseFvCache(req);
+    SolrQueryRequestContextUtils.setIsExtractingFeatures(req);
 
     // Communicate which feature store we are requesting features for
     SolrQueryRequestContextUtils.setFvStoreName(req, params.get(FV_STORE));

--- a/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
@@ -32,6 +32,7 @@ import org.apache.solr.ltr.ModelQuery;
 import org.apache.solr.ltr.ModelQuery.FeatureInfo;
 import org.apache.solr.ltr.ModelQuery.ModelWeight;
 import org.apache.solr.ltr.ModelQuery.ModelWeight.ModelScorer;
+import org.apache.solr.ltr.SolrQueryRequestContextUtils;
 import org.apache.solr.ltr.model.LoggingModel;
 import org.apache.solr.ltr.store.FeatureStore;
 import org.apache.solr.ltr.store.rest.ManagedFeatureStore;
@@ -52,26 +53,17 @@ import org.apache.solr.util.SolrPluginUtils;
 public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
 
   // used inside fl to specify the output format (csv/json) of the extracted features
-  public static final String FV_RESPONSE_WRITER = "fvwt";
+  private static final String FV_RESPONSE_WRITER = "fvwt";
 
   // used inside fl to specify the format (dense|sparse) of the extracted features
-  public static final String FV_FORMAT = "format";
+  private static final String FV_FORMAT = "format";
 
   // used inside fl to specify the feature store to use for the feature extraction
-  public static final String FV_STORE = "store";
-
-  public static FeatureLogger<?> createFeatureLogger(SolrQueryRequest req) {
-    final String stringFormat = (String) req.getContext().get(FV_RESPONSE_WRITER);
-    final String featureFormat = (String) req.getContext().get(FV_FORMAT);
-    return FeatureLogger.createFeatureLogger(stringFormat, featureFormat);
-  }
+  private static final String FV_STORE = "store";
 
   public static String DEFAULT_LOGGING_MODEL_NAME = "logging-model";
 
   private String loggingModelName = DEFAULT_LOGGING_MODEL_NAME;
-
-  /** key of the ModelQuery in the request context **/
-  public static final String MODEL_QUERY = "model";
 
   /**
    * if the log feature query param is off features will not be logged.
@@ -93,10 +85,16 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
       SolrQueryRequest req) {
 
     // Hint to enable feature vector cache since we are requesting features
-    req.getContext().put(LOG_FEATURES_QUERY_PARAM, true);
-    req.getContext().put(FV_STORE, params.get(FV_STORE));
-    req.getContext().put(FV_FORMAT, params.get(FV_FORMAT));
-    req.getContext().put(FV_RESPONSE_WRITER, params.get(FV_RESPONSE_WRITER));
+    SolrQueryRequestContextUtils.setUseFvCache(req);
+
+    // Communicate which feature store we are requesting features for
+    SolrQueryRequestContextUtils.setFvStoreName(req, params.get(FV_STORE));
+
+    // Create and supply the feature logger to be used
+    SolrQueryRequestContextUtils.setFeatureLogger(req,
+        FeatureLogger.createFeatureLogger(
+            params.get(FV_RESPONSE_WRITER),
+            params.get(FV_FORMAT)));
 
     return new FeatureTransformer(name, params, req);
   }
@@ -150,9 +148,9 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
       leafContexts = searcher.getTopReaderContext().leaves();
 
       // Setup ModelQuery
-      reRankModel = (ModelQuery) req.getContext().get(MODEL_QUERY);
+      reRankModel = SolrQueryRequestContextUtils.getModelQuery(req);
       resultsReranked = (reRankModel != null);
-      String featureStoreName = (String)req.getContext().get(FV_STORE);
+      String featureStoreName = SolrQueryRequestContextUtils.getFvStoreName(req);
       if (!resultsReranked || (featureStoreName != null && (!featureStoreName.equals(reRankModel.getScoringModel().getFeatureStoreName())))) {
         // if store is set in the trasformer we should overwrite the logger
 
@@ -180,7 +178,7 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
       }
 
       if (reRankModel.getFeatureLogger() == null){
-        reRankModel.setFeatureLogger( createFeatureLogger(req) );
+        reRankModel.setFeatureLogger( SolrQueryRequestContextUtils.getFeatureLogger(req) );
       }
       reRankModel.setRequest(req);
 

--- a/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
@@ -187,7 +187,7 @@ public class LTRQParserPlugin extends QParserPlugin implements ResourceLoaderAwa
       }
 
       final String modelFeatureStoreName = meta.getFeatureStoreName();
-      final boolean extractFeatures = SolrQueryRequestContextUtils.useFvCache(req);
+      final boolean extractFeatures = SolrQueryRequestContextUtils.isExtractingFeatures(req);
       final String fvStoreName = SolrQueryRequestContextUtils.getFvStoreName(req);
       // Check if features are requested and if the model feature store and feature-transform feature store are the same
       final boolean featuresRequestedFromSameStore = (modelFeatureStoreName.equals(fvStoreName) || fvStoreName == null) ? extractFeatures:false;

--- a/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
@@ -33,12 +33,12 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.ltr.LTRRescorer;
 import org.apache.solr.ltr.LTRThreadModule;
 import org.apache.solr.ltr.ModelQuery;
+import org.apache.solr.ltr.SolrQueryRequestContextUtils;
 import org.apache.solr.ltr.model.LTRScoringModel;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.ltr.store.rest.ManagedFeatureStore;
 import org.apache.solr.ltr.store.rest.ManagedModelStore;
 import org.apache.solr.request.SolrQueryRequest;
-import org.apache.solr.response.transform.LTRFeatureLoggerTransformerFactory;
 import org.apache.solr.rest.ManagedResource;
 import org.apache.solr.rest.ManagedResourceObserver;
 import org.apache.solr.rest.RestManager;
@@ -187,10 +187,10 @@ public class LTRQParserPlugin extends QParserPlugin implements ResourceLoaderAwa
       }
 
       final String modelFeatureStoreName = meta.getFeatureStoreName();
-      final Boolean extractFeatures = (Boolean) req.getContext().get(LTRFeatureLoggerTransformerFactory.LOG_FEATURES_QUERY_PARAM);
-      final String fvStoreName = (String) req.getContext().get(LTRFeatureLoggerTransformerFactory.FV_STORE);
+      final boolean extractFeatures = SolrQueryRequestContextUtils.useFvCache(req);
+      final String fvStoreName = SolrQueryRequestContextUtils.getFvStoreName(req);
       // Check if features are requested and if the model feature store and feature-transform feature store are the same
-      final boolean featuresRequestedFromSameStore = (extractFeatures != null && (modelFeatureStoreName.equals(fvStoreName) || fvStoreName == null) ) ? extractFeatures.booleanValue():false;
+      final boolean featuresRequestedFromSameStore = (modelFeatureStoreName.equals(fvStoreName) || fvStoreName == null) ? extractFeatures:false;
       
       final ModelQuery reRankModel = new ModelQuery(meta, 
           extractEFIParams(localParams), 
@@ -199,9 +199,9 @@ public class LTRQParserPlugin extends QParserPlugin implements ResourceLoaderAwa
       // Enable the feature vector caching if we are extracting features, and the features
       // we requested are the same ones we are reranking with 
       if (featuresRequestedFromSameStore) {
-        reRankModel.setFeatureLogger( LTRFeatureLoggerTransformerFactory.createFeatureLogger(req) );
+        reRankModel.setFeatureLogger( SolrQueryRequestContextUtils.getFeatureLogger(req) );
       }
-      req.getContext().put(LTRFeatureLoggerTransformerFactory.MODEL_QUERY, reRankModel);
+      SolrQueryRequestContextUtils.setModelQuery(req, reRankModel);
 
       int reRankDocs = localParams.getInt(RERANK_DOCS, DEFAULT_RERANK_DOCS);
       reRankDocs = Math.max(1, reRankDocs);


### PR DESCRIPTION
motivations:
 * to make it clearer how LTR uses the request context
 * to help avoid request context key clashes with other code
 * to separate the client-facing params (store,fvwt,format) from the request context keys

bonus benefit:
 * from the factoring out it became clear that instead of storing fw.fvwt and fv.format
   in the request context the feature logger corresponding to it can be stored instead