### PR TITLE
revert accidental rename

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -153,7 +153,7 @@ public class LTRRescorer extends Rescorer {
 
     ModelScorer scorer = null;
     int hitUpto = 0;
-    final FeatureLogger<?> featureLogger = reRankModel.createFeatureLogger();
+    final FeatureLogger<?> featureLogger = reRankModel.getFeatureLogger();
 
     // FIXME
     // All of this heap code is only for logging. Wrap all this code in

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/ModelQuery.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/ModelQuery.java
@@ -100,7 +100,7 @@ public class ModelQuery extends Query {
     this.fl = fl;
   }
 
-  public FeatureLogger createFeatureLogger() {
+  public FeatureLogger getFeatureLogger() {
     return fl;
   }
 

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/SolrQueryRequestContextUtils.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/SolrQueryRequestContextUtils.java
@@ -41,7 +41,7 @@ public class SolrQueryRequestContextUtils {
     req.getContext().put(FEATURE_LOGGER, featureLogger);
   }
 
-  public static FeatureLogger<?> createFeatureLogger(SolrQueryRequest req) {
+  public static FeatureLogger<?> getFeatureLogger(SolrQueryRequest req) {
     return (FeatureLogger<?>) req.getContext().get(FEATURE_LOGGER);
   }
 

--- a/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
@@ -174,12 +174,12 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
         }
       }
 
-      if (reRankModel.createFeatureLogger() == null){
-        reRankModel.setFeatureLogger( SolrQueryRequestContextUtils.createFeatureLogger(req) );
+      if (reRankModel.getFeatureLogger() == null){
+        reRankModel.setFeatureLogger( SolrQueryRequestContextUtils.getFeatureLogger(req) );
       }
       reRankModel.setRequest(req);
 
-      featureLogger = reRankModel.createFeatureLogger();
+      featureLogger = reRankModel.getFeatureLogger();
 
       try {
         modelWeight = reRankModel.createWeight(searcher, true, 1f);

--- a/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
@@ -199,7 +199,7 @@ public class LTRQParserPlugin extends QParserPlugin implements ResourceLoaderAwa
       // Enable the feature vector caching if we are extracting features, and the features
       // we requested are the same ones we are reranking with 
       if (featuresRequestedFromSameStore) {
-        reRankModel.setFeatureLogger( SolrQueryRequestContextUtils.createFeatureLogger(req) );
+        reRankModel.setFeatureLogger( SolrQueryRequestContextUtils.getFeatureLogger(req) );
       }
       SolrQueryRequestContextUtils.setModelQuery(req, reRankModel);
 


### PR DESCRIPTION
(getFeatureLogger vs. createFeatureLogger)

(#142 follow-on)