### PR TITLE
factor out ManagedStoreUtils class

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedFeatureStore.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedFeatureStore.java
@@ -26,12 +26,14 @@ import java.util.Map;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.ltr.feature.Feature;
 import org.apache.solr.ltr.store.FeatureStore;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.rest.BaseSolrResource;
 import org.apache.solr.rest.ManagedResource;
+import org.apache.solr.rest.ManagedResourceObserver;
 import org.apache.solr.rest.ManagedResourceStorage.StorageIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +43,19 @@ import org.slf4j.LoggerFactory;
  */
 public class ManagedFeatureStore extends ManagedResource implements
     ManagedResource.ChildResourceSupport {
+
+  public static void registerManagedFeatureStore(SolrResourceLoader solrResourceLoader,
+      ManagedResourceObserver managedResourceObserver) {
+    solrResourceLoader.getManagedResourceRegistry().registerManagedResource(
+        REST_END_POINT,
+        ManagedFeatureStore.class,
+        managedResourceObserver);
+  }
+
+  public static ManagedFeatureStore getManagedFeatureStore(SolrCore core) {
+    return (ManagedFeatureStore) core.getRestManager()
+        .getManagedResource(REST_END_POINT);
+  }
 
   /** the feature store rest endpoint **/
   public static final String REST_END_POINT = "/schema/feature-store";

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.ltr.feature.Feature;
 import org.apache.solr.ltr.model.LTRScoringModel;
@@ -35,6 +36,7 @@ import org.apache.solr.ltr.store.ModelStore;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.rest.BaseSolrResource;
 import org.apache.solr.rest.ManagedResource;
+import org.apache.solr.rest.ManagedResourceObserver;
 import org.apache.solr.rest.ManagedResourceStorage.StorageIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +46,19 @@ import org.slf4j.LoggerFactory;
  */
 public class ManagedModelStore extends ManagedResource implements
     ManagedResource.ChildResourceSupport {
+
+  public static void registerManagedModelStore(SolrResourceLoader solrResourceLoader,
+      ManagedResourceObserver managedResourceObserver) {
+    solrResourceLoader.getManagedResourceRegistry().registerManagedResource(
+        REST_END_POINT,
+        ManagedModelStore.class,
+        managedResourceObserver);
+  }
+
+  public static ManagedModelStore getManagedModelStore(SolrCore core) {
+    return (ManagedModelStore) core.getRestManager()
+        .getManagedResource(REST_END_POINT);
+  }
 
   /** the model store rest endpoint **/
   public static final String REST_END_POINT = "/schema/model-store";

--- a/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/response/transform/LTRFeatureLoggerTransformerFactory.java
@@ -151,8 +151,7 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
       if (docsWereNotReranked || (featureStoreName != null && (!featureStoreName.equals(scoringQuery.getScoringModel().getFeatureStoreName())))) {
         // if store is set in the transformer we should overwrite the logger
 
-        final ManagedFeatureStore fr = (ManagedFeatureStore) req.getCore().getRestManager()
-            .getManagedResource(ManagedFeatureStore.REST_END_POINT);
+        final ManagedFeatureStore fr = ManagedFeatureStore.getManagedFeatureStore(req.getCore());
 
         final FeatureStore store = fr.getFeatureStore(featureStoreName);
         featureStoreName = store.getName(); // if featureStoreName was null before this gets actual name

--- a/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
@@ -41,7 +41,6 @@ import org.apache.solr.ltr.store.rest.ManagedModelStore;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.rest.ManagedResource;
 import org.apache.solr.rest.ManagedResourceObserver;
-import org.apache.solr.rest.RestManager;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.QParserPlugin;
 import org.apache.solr.search.SyntaxError;
@@ -136,17 +135,8 @@ public class LTRQParserPlugin extends QParserPlugin implements ResourceLoaderAwa
   @Override
   public void inform(ResourceLoader loader) throws IOException {
     final SolrResourceLoader solrResourceLoader = (SolrResourceLoader) loader;
-    final RestManager.Registry registry = solrResourceLoader.getManagedResourceRegistry();
-
-    registry.registerManagedResource(
-        ManagedFeatureStore.REST_END_POINT,
-        ManagedFeatureStore.class,
-        this);
-
-    registry.registerManagedResource(
-        ManagedModelStore.REST_END_POINT,
-        ManagedModelStore.class,
-        this);
+    ManagedFeatureStore.registerManagedFeatureStore(solrResourceLoader, this);
+    ManagedModelStore.registerManagedModelStore(solrResourceLoader, this);
   }
 
   @Override
@@ -170,9 +160,6 @@ public class LTRQParserPlugin extends QParserPlugin implements ResourceLoaderAwa
     public LTRQParser(String qstr, SolrParams localParams, SolrParams params,
         SolrQueryRequest req) {
       super(qstr, localParams, params, req);
-
-      mr = (ManagedModelStore) req.getCore().getRestManager()
-          .getManagedResource(ManagedModelStore.REST_END_POINT);
     }
 
     @Override

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
@@ -88,21 +88,12 @@ public class TestRerankBase extends RestTestBase {
     bulkIndex();
   }
 
-  // NOTE: this will return a new rest manager since the getCore() method
-  // returns a new instance of a restManager.
-  public static ManagedFeatureStore getNewManagedFeatureStore() {
-    final ManagedFeatureStore fs = (ManagedFeatureStore) h.getCore()
-        .getRestManager()
-        .getManagedResource(ManagedFeatureStore.REST_END_POINT);
-    return fs;
+  public static ManagedFeatureStore getManagedFeatureStore() {
+    return ManagedFeatureStore.getManagedFeatureStore(h.getCore());
   }
 
-  public static ManagedModelStore getNewManagedModelStore() {
-
-    final ManagedModelStore fs = (ManagedModelStore) h.getCore()
-        .getRestManager()
-        .getManagedResource(ManagedModelStore.REST_END_POINT);
-    return fs;
+  public static ManagedModelStore getManagedModelStore() {
+    return ManagedModelStore.getManagedModelStore(h.getCore());
   }
   
   protected static SortedMap<ServletHolder,String>  setupTestInit(
@@ -287,7 +278,7 @@ public class TestRerankBase extends RestTestBase {
         + modelFileName);
     final String modelJson = FileUtils.readFileToString(new File(url.toURI()),
         "UTF-8");
-    final ManagedModelStore ms = getNewManagedModelStore();
+    final ManagedModelStore ms = getManagedModelStore();
 
     url = TestRerankBase.class.getResource("/featureExamples/"
         + featureFileName);
@@ -301,7 +292,7 @@ public class TestRerankBase extends RestTestBase {
       throw new ModelException("ObjectBuilder failed parsing json", ioExc);
     }
 
-    final ManagedFeatureStore fs = getNewManagedFeatureStore();
+    final ManagedFeatureStore fs = getManagedFeatureStore();
     // fs.getFeatureStore(null).clear();
     fs.doDeleteChild(null, "*"); // is this safe??
     // based on my need to call this I dont think that

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLtrScoringModel.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLtrScoringModel.java
@@ -33,7 +33,7 @@ public class TestFeatureLtrScoringModel extends TestRerankBase {
   @BeforeClass
   public static void setup() throws Exception {
     setuptest();
-    store = getNewManagedFeatureStore();
+    store = getManagedFeatureStore();
   }
 
   @AfterClass

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureStore.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureStore.java
@@ -32,7 +32,7 @@ public class TestFeatureStore extends TestRerankBase {
   @BeforeClass
   public static void setup() throws Exception {
     setuptest();
-    fstore = getNewManagedFeatureStore();
+    fstore = getManagedFeatureStore();
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/model/TestRankSVMModel.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/model/TestRankSVMModel.java
@@ -56,8 +56,8 @@ public class TestRankSVMModel extends TestRerankBase {
   public static void setup() throws Exception {
     setuptest();
     // loadFeatures("features-store-test-model.json");
-    store = getNewManagedModelStore();
-    fstore = getNewManagedFeatureStore().getFeatureStore("test");
+    store = getManagedModelStore();
+    fstore = getManagedFeatureStore().getFeatureStore("test");
 
   }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManagerPersistence.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManagerPersistence.java
@@ -24,8 +24,6 @@ import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.feature.ValueFeature;
 import org.apache.solr.ltr.model.RankSVMModel;
-import org.apache.solr.ltr.store.rest.ManagedFeatureStore;
-import org.apache.solr.ltr.store.rest.ManagedModelStore;
 import org.junit.Before;
 import org.junit.Test;
 import org.noggit.ObjectBuilder;


### PR DESCRIPTION
motivation: to reduce number of places that interact with RestManager (and to thus maybe make it clearer where the rest stuff is used without distraction of end-point-name details and rest manager method details)

(also rename getNewManaged...Store to getManaged...Store in tests)