### PR TITLE
rename LTRMax[Query]Threads to max[Query]Threads

### DIFF
--- a/solr/contrib/ltr/README.md
+++ b/solr/contrib/ltr/README.md
@@ -391,12 +391,12 @@ About half the time for ranking is spent in the creation of weights for each fea
 <config>
   <!-- Query parser used to rerank top docs with a provided model -->
   <queryParser name="ltr" class="org.apache.solr.search.LTRQParserPlugin">
-     <int name="LTRMaxThreads">10</int> <!-- Maximum threads to use for all queries -->
-     <int name="LTRMaxQueryThreads">5</int> <!-- Maximum threads to use for a single query-->
+     <int name="maxThreads">10</int> <!-- Maximum threads to use for all queries -->
+     <int name="maxQueryThreads">5</int> <!-- Maximum threads to use for a single query-->
   </queryParser>
 </config>
 
 ```
   
-The LTRMaxThreads option limits the total number of threads to be used across all query instances at any given time. LTRMaxQueryThreads limits the number of threads used to process a single query. In the above example, 10 threads will be used to services all queries and a maximum of 5 threads to service a single query. If the solr instances is expected to receive no more than one query at a time, it is best to set both these numbers to the same value. If multiple queries need to serviced simultaneously, the numbers can be adjusted based on the expected response times. If the value of  LTRMaxQueryThreads is higher, the reponse time for a single query will be improved upto a point. If multiple queries are services simultaneously, the LTRMaxThreads imposes a contention between the queries if (LTRMaxQueryThreads*total parallel queries > LTRMaxThreads). 
+The maxThreads option limits the total number of threads to be used across all query instances at any given time. maxQueryThreads limits the number of threads used to process a single query. In the above example, 10 threads will be used to services all queries and a maximum of 5 threads to service a single query. If the solr instances is expected to receive no more than one query at a time, it is best to set both these numbers to the same value. If multiple queries need to serviced simultaneously, the numbers can be adjusted based on the expected response times. If the value of  maxQueryThreads is higher, the reponse time for a single query will be improved upto a point. If multiple queries are services simultaneously, the maxThreads imposes a contention between the queries if (maxQueryThreads*total parallel queries > maxThreads). 
 

--- a/solr/contrib/ltr/example/solrconfig.xml
+++ b/solr/contrib/ltr/example/solrconfig.xml
@@ -858,8 +858,8 @@
 
  <!-- Query parser used to rerank top docs with a provided model -->
   <queryParser name="ltr" class="org.apache.solr.search.LTRQParserPlugin" >
-  <int name="LTRMaxThreads">10</int> <!-- Maximum threads to use for all queries -->
-  <int name="LTRMaxQueryThreads">10</int> <!-- Maximum threads to use for a single query-->
+  <int name="maxThreads">10</int> <!-- Maximum threads to use for all queries -->
+  <int name="maxQueryThreads">10</int> <!-- Maximum threads to use for a single query-->
   </queryParser>
 
   <!--  Transformer that will encode the document features in the response. For each document the transformer

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRThreadModule.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRThreadModule.java
@@ -31,8 +31,8 @@ public class LTRThreadModule {
   private Semaphore ltrSemaphore = null; 
   private int maxThreads;
   private int maxQueryThreads;
-  public static final int DEFAULT_MAX_THREADS = 0; // do not do threading if 'LTRMaxThreads' is not specified in the config file
-  public static final int DEFAULT_MAX_QUERYTHREADS = 0; // do not do threading if 'LTRMaxQueryThreads' is not specified in the config file
+  public static final int DEFAULT_MAX_THREADS = 0; // do not do threading if 'maxThreads' is not specified in the config file
+  public static final int DEFAULT_MAX_QUERYTHREADS = 0; // do not do threading if 'maxQueryThreads' is not specified in the config file
 
    private final Executor createWeightScoreExecutor = new ExecutorUtil.MDCAwareThreadPoolExecutor(
           0,
@@ -46,13 +46,13 @@ public class LTRThreadModule {
       this.maxThreads = maxThreads;
       this.maxQueryThreads = maxQueryThreads;
       if (maxThreads < 0){
-        throw new NumberFormatException("LTRMaxThreads cannot be less than 0");
+        throw new NumberFormatException("maxThreads cannot be less than 0");
       }
       if (maxQueryThreads < 0){
-        throw new NumberFormatException("LTRMaxQueryThreads cannot be less than 0");
+        throw new NumberFormatException("maxQueryThreads cannot be less than 0");
       }
       if (maxThreads < maxQueryThreads){
-        throw new NumberFormatException("LTRMaxQueryThreads cannot be greater than LTRMaxThreads");
+        throw new NumberFormatException("maxQueryThreads cannot be greater than maxThreads");
       }
       if  (this.maxThreads > 1 ){
         ltrSemaphore = new Semaphore(maxThreads);

--- a/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/search/LTRQParserPlugin.java
@@ -97,8 +97,8 @@ public class LTRQParserPlugin extends QParserPlugin implements ResourceLoaderAwa
 
   @Override
   public void init(@SuppressWarnings("rawtypes") NamedList args) {
-    int maxThreads  = getInt(args.get("LTRMaxThreads"), LTRThreadModule.DEFAULT_MAX_THREADS, "LTRMaxThreads");
-    int maxQueryThreads = getInt(args.get("LTRMaxQueryThreads"), LTRThreadModule.DEFAULT_MAX_QUERYTHREADS, "LTRMaxQueryThreads");
+    int maxThreads  = getInt(args.get("maxThreads"), LTRThreadModule.DEFAULT_MAX_THREADS, "maxThreads");
+    int maxQueryThreads = getInt(args.get("maxQueryThreads"), LTRThreadModule.DEFAULT_MAX_QUERYTHREADS, "maxQueryThreads");
     threadManager = new LTRThreadModule(maxThreads, maxQueryThreads);
   }
   

--- a/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr_Th10_10.xml
+++ b/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr_Th10_10.xml
@@ -22,8 +22,8 @@
  <!-- Query parser used to rerank top docs with a provided model -->
  <queryParser name="ltr"
   class="org.apache.solr.search.LTRQParserPlugin" >
-   <int name="LTRMaxThreads">10</int> <!-- Maximum threads to use for all queries -->
-     <int name="LTRMaxQueryThreads">10</int> <!-- Maximum threads to use for a single query-->
+   <int name="maxThreads">10</int> <!-- Maximum threads to use for all queries -->
+     <int name="maxQueryThreads">10</int> <!-- Maximum threads to use for a single query-->
  </queryParser>
 
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestParallelWeightCreation.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestParallelWeightCreation.java
@@ -65,15 +65,15 @@ public class TestParallelWeightCreation extends TestRerankBase{
     }catch(NumberFormatException nfe){
       msg1 = nfe.getMessage();;
     }
-    assertTrue(msg1.equals("LTRMaxQueryThreads cannot be less than 0"));
+    assertTrue(msg1.equals("maxQueryThreads cannot be less than 0"));
     
-    // set LTRMaxThreads to 1 and LTRMaxQueryThreads to 2 and verify that an exception is thrown
+    // set maxThreads to 1 and maxQueryThreads to 2 and verify that an exception is thrown
     String msg2 = null;
     try{
       new LTRThreadModule(1,2);
     }catch(NumberFormatException nfe){
       msg2 = nfe.getMessage();
     }
-    assertTrue(msg2.equals("LTRMaxQueryThreads cannot be greater than LTRMaxThreads"));
+    assertTrue(msg2.equals("maxQueryThreads cannot be greater than maxThreads"));
   }
 }


### PR DESCRIPTION
(in line with other solrconfig.xml elements)

(and the LTR is already there in the fully qualified class path)