### PR TITLE
remove CSVFeatureLogger separator/delimiter assumptions in tests

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
@@ -151,8 +151,8 @@ public abstract class FeatureLogger<FV_TYPE> {
   }
 
   public static class CSVFeatureLogger extends FeatureLogger<String> {
-    private static final char DEFAULT_KEY_VALUE_SEPARATOR = ':';
-    private static final char DEFAULT_FEATURE_SEPARATOR = ';';
+    static final char DEFAULT_KEY_VALUE_SEPARATOR = ':';
+    static final char DEFAULT_FEATURE_SEPARATOR = ';';
     char keyValueSep = DEFAULT_KEY_VALUE_SEPARATOR;
     char featureSep = DEFAULT_FEATURE_SEPARATOR;
 
@@ -187,33 +187,6 @@ public abstract class FeatureLogger<FV_TYPE> {
       }
 
       final String features = (sb.length() > 0 ? 
-          sb.substring(0, sb.length() - 1) : "");
-
-      return features;
-    }
-
-    /*
-     * For test use only.
-     */
-    public static String toFeatureVector(String ... keysAndValues) {
-      return toFeatureVector(DEFAULT_KEY_VALUE_SEPARATOR, DEFAULT_FEATURE_SEPARATOR,
-          keysAndValues);
-    }
-
-    /*
-     * For test use only.
-     */
-    public static String toFeatureVector(char keyValueSeparator, char featureSeparator,
-        String ... keysAndValues) {
-      StringBuilder sb = new StringBuilder(keysAndValues.length/2 * 3);
-      for (int ii = 0; ii+1 < keysAndValues.length; ii += 2) {
-          sb.append(keysAndValues[ii])
-          .append(keyValueSeparator)
-          .append(keysAndValues[ii+1])
-          .append(featureSeparator);
-      }
-
-      final String features = (sb.length() > 0 ?
           sb.substring(0, sb.length() - 1) : "");
 
       return features;

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
@@ -151,8 +151,10 @@ public abstract class FeatureLogger<FV_TYPE> {
   }
 
   public static class CSVFeatureLogger extends FeatureLogger<String> {
-    char keyValueSep = ':';
-    char featureSep = ';';
+    public static final char DEFAULT_KEY_VALUE_SEPARATOR = ':';
+    public static final char DEFAULT_FEATURE_SEPARATOR = ';';
+    char keyValueSep = DEFAULT_KEY_VALUE_SEPARATOR;
+    char featureSep = DEFAULT_FEATURE_SEPARATOR;
 
     public CSVFeatureLogger(FeatureFormat f) {
       super(f);

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
@@ -192,6 +192,33 @@ public abstract class FeatureLogger<FV_TYPE> {
       return features;
     }
 
+    /*
+     * For test use only.
+     */
+    public static String toFeatureVector(String ... keysAndValues) {
+      return toFeatureVector(DEFAULT_KEY_VALUE_SEPARATOR, DEFAULT_FEATURE_SEPARATOR,
+          keysAndValues);
+    }
+
+    /*
+     * For test use only.
+     */
+    public static String toFeatureVector(char keyValueSeparator, char featureSeparator,
+        String ... keysAndValues) {
+      StringBuilder sb = new StringBuilder(keysAndValues.length/2 * 3);
+      for (int ii = 0; ii+1 < keysAndValues.length; ii += 2) {
+          sb.append(keysAndValues[ii])
+          .append(keyValueSeparator)
+          .append(keysAndValues[ii+1])
+          .append(featureSeparator);
+      }
+
+      final String features = (sb.length() > 0 ?
+          sb.substring(0, sb.length() - 1) : "");
+
+      return features;
+    }
+
   }
 
 }

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
@@ -151,8 +151,8 @@ public abstract class FeatureLogger<FV_TYPE> {
   }
 
   public static class CSVFeatureLogger extends FeatureLogger<String> {
-    public static final char DEFAULT_KEY_VALUE_SEPARATOR = ':';
-    public static final char DEFAULT_FEATURE_SEPARATOR = ';';
+    private static final char DEFAULT_KEY_VALUE_SEPARATOR = ':';
+    private static final char DEFAULT_FEATURE_SEPARATOR = ';';
     char keyValueSep = DEFAULT_KEY_VALUE_SEPARATOR;
     char featureSep = DEFAULT_FEATURE_SEPARATOR;
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/FeatureLoggerTestUtils.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/FeatureLoggerTestUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.ltr;
+
+public class FeatureLoggerTestUtils {
+
+  public static String toFeatureVector(String ... keysAndValues) {
+    return toFeatureVector(
+        FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR,
+        FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR,
+        keysAndValues);
+  }
+
+  public static String toFeatureVector(char keyValueSeparator, char featureSeparator,
+      String ... keysAndValues) {
+    StringBuilder sb = new StringBuilder(keysAndValues.length/2 * 3);
+    for (int ii = 0; ii+1 < keysAndValues.length; ii += 2) {
+        sb.append(keysAndValues[ii])
+        .append(keyValueSeparator)
+        .append(keysAndValues[ii+1])
+        .append(featureSeparator);
+    }
+
+    final String features = (sb.length() > 0 ?
+        sb.substring(0, sb.length() - 1) : "");
+
+    return features;
+  }
+
+}

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
@@ -92,17 +92,14 @@ public class TestLTROnSolrCloud extends TestRerankBase {
     assertEquals("3", queryResponse.getResults().get(2).get("id").toString());
     assertEquals("4", queryResponse.getResults().get(3).get("id").toString());
 
-    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
-
-    final String result0_features = "powpularityS"+csv_keyvalue_separator+"64.0"
-        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
-    final String result1_features = "powpularityS"+csv_keyvalue_separator+"49.0"
-        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
-    final String result2_features = "powpularityS"+csv_keyvalue_separator+"36.0"
-        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
-    final String result3_features = "powpularityS"+csv_keyvalue_separator+"25.0"
-        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
+    final String result0_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "powpularityS","64.0", "c3","2.0");
+    final String result1_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "powpularityS","49.0", "c3","2.0");
+    final String result2_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "powpularityS","36.0", "c3","2.0");
+    final String result3_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "powpularityS","25.0", "c3","2.0");
 
     // Test re-rank and feature vectors returned
     query.setFields("*,score,features:[fv]");

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
@@ -92,13 +92,13 @@ public class TestLTROnSolrCloud extends TestRerankBase {
     assertEquals("3", queryResponse.getResults().get(2).get("id").toString());
     assertEquals("4", queryResponse.getResults().get(3).get("id").toString());
 
-    final String result0_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String result0_features= FeatureLoggerTestUtils.toFeatureVector(
         "powpularityS","64.0", "c3","2.0");
-    final String result1_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String result1_features= FeatureLoggerTestUtils.toFeatureVector(
         "powpularityS","49.0", "c3","2.0");
-    final String result2_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String result2_features= FeatureLoggerTestUtils.toFeatureVector(
         "powpularityS","36.0", "c3","2.0");
-    final String result3_features= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String result3_features= FeatureLoggerTestUtils.toFeatureVector(
         "powpularityS","25.0", "c3","2.0");
 
     // Test re-rank and feature vectors returned

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
@@ -92,6 +92,18 @@ public class TestLTROnSolrCloud extends TestRerankBase {
     assertEquals("3", queryResponse.getResults().get(2).get("id").toString());
     assertEquals("4", queryResponse.getResults().get(3).get("id").toString());
 
+    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
+    final String result0_features = "powpularityS"+csv_keyvalue_separator+"64.0"
+        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
+    final String result1_features = "powpularityS"+csv_keyvalue_separator+"49.0"
+        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
+    final String result2_features = "powpularityS"+csv_keyvalue_separator+"36.0"
+        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
+    final String result3_features = "powpularityS"+csv_keyvalue_separator+"25.0"
+        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"2.0";
+
     // Test re-rank and feature vectors returned
     query.setFields("*,score,features:[fv]");
     query.add("rq", "{!ltr model=powpularityS-model reRankDocs=8}");
@@ -99,16 +111,16 @@ public class TestLTROnSolrCloud extends TestRerankBase {
         solrCluster.getSolrClient().query(COLLECTION,query);
     assertEquals(8, queryResponse.getResults().getNumFound());
     assertEquals("8", queryResponse.getResults().get(0).get("id").toString());
-    assertEquals("powpularityS:64.0;c3:2.0",
+    assertEquals(result0_features,
         queryResponse.getResults().get(0).get("features").toString());
     assertEquals("7", queryResponse.getResults().get(1).get("id").toString());
-    assertEquals("powpularityS:49.0;c3:2.0",
+    assertEquals(result1_features,
         queryResponse.getResults().get(1).get("features").toString());
     assertEquals("6", queryResponse.getResults().get(2).get("id").toString());
-    assertEquals("powpularityS:36.0;c3:2.0",
+    assertEquals(result2_features,
         queryResponse.getResults().get(2).get("features").toString());
     assertEquals("5", queryResponse.getResults().get(3).get("id").toString());
-    assertEquals("powpularityS:25.0;c3:2.0",
+    assertEquals(result3_features,
         queryResponse.getResults().get(3).get("features").toString());
   }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
@@ -215,6 +215,12 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
   @Test
   public void testSelectiveWeightsRequestFeaturesFromDifferentStore() throws Exception {
 
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char value_delim = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
+    final String docs0fv = "'matchedTitle"+keyvalue_sep+"1.0"+value_delim+"titlePhraseMatch"+keyvalue_sep+"0.40254828'";
+    final String docs0fv_fstore4 = "'popularity"+keyvalue_sep+"3.0"+value_delim+"originalScore"+keyvalue_sep+"1.0'";
+
     final SolrQuery query = new SolrQuery();
     query.setQuery("*:*");
     query.add("fl", "*,score");
@@ -225,7 +231,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='3'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='4'");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='matchedTitle:1.0;titlePhraseMatch:0.40254828'"); // extract all features in default store
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv); // extract all features in default store
 
     query.remove("fl");
     query.remove("rq");
@@ -235,7 +241,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
 
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==0.999");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='popularity:3.0;originalScore:1.0'"); // extract all features from fstore4
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv_fstore4); // extract all features from fstore4
 
 
     query.remove("fl");
@@ -245,7 +251,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
     query.add("fl", "fv:[fv store=fstore4 efi.myPop=3]");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'"); // score using fstore2 used by externalmodelstore
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==0.7992");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='popularity:3.0;originalScore:1.0'"); // extract all features from fstore4
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv_fstore4); // extract all features from fstore4
   }
 }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
@@ -215,9 +215,9 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
   @Test
   public void testSelectiveWeightsRequestFeaturesFromDifferentStore() throws Exception {
 
-    final String docs0fv = FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String docs0fv = FeatureLoggerTestUtils.toFeatureVector(
         "matchedTitle","1.0", "titlePhraseMatch","0.40254828");
-    final String docs0fv_fstore4= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String docs0fv_fstore4= FeatureLoggerTestUtils.toFeatureVector(
         "popularity","3.0", "originalScore","1.0");
 
     final SolrQuery query = new SolrQuery();

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
@@ -215,11 +215,10 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
   @Test
   public void testSelectiveWeightsRequestFeaturesFromDifferentStore() throws Exception {
 
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-    final char value_delim = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
-
-    final String docs0fv = "'matchedTitle"+keyvalue_sep+"1.0"+value_delim+"titlePhraseMatch"+keyvalue_sep+"0.40254828'";
-    final String docs0fv_fstore4 = "'popularity"+keyvalue_sep+"3.0"+value_delim+"originalScore"+keyvalue_sep+"1.0'";
+    final String docs0fv = FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "matchedTitle","1.0", "titlePhraseMatch","0.40254828");
+    final String docs0fv_fstore4= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "popularity","3.0", "originalScore","1.0");
 
     final SolrQuery query = new SolrQuery();
     query.setQuery("*:*");
@@ -231,7 +230,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='3'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='4'");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv); // extract all features in default store
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='"+docs0fv+"'"); // extract all features in default store
 
     query.remove("fl");
     query.remove("rq");
@@ -241,7 +240,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
 
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==0.999");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv_fstore4); // extract all features from fstore4
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='"+docs0fv_fstore4+"'"); // extract all features from fstore4
 
 
     query.remove("fl");
@@ -251,7 +250,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
     query.add("fl", "fv:[fv store=fstore4 efi.myPop=3]");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'"); // score using fstore2 used by externalmodelstore
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==0.7992");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv_fstore4); // extract all features from fstore4
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='"+docs0fv_fstore4+"'"); // extract all features from fstore4
   }
 }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
@@ -104,11 +104,8 @@ public class TestExternalFeatures extends TestRerankBase {
     query.setQuery("*:*");
     query.add("rows", "1");
 
-    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
-
-    final String docs0fv_sparse_csv = "'confidence"+csv_keyvalue_separator+"2.3"
-        + csv_value_delimiter + "originalScore"+csv_keyvalue_separator+"1.0'";
+    final String docs0fv_sparse_csv = FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "confidence","2.3", "originalScore","1.0");
 
     // Features we're extracting depend on external feature info not passed in
     query.add("fl", "[fv]");
@@ -117,13 +114,13 @@ public class TestExternalFeatures extends TestRerankBase {
     // Adding efi in features section should make it work
     query.remove("fl");
     query.add("fl", "score,fvalias:[fv store=fstore2 efi.myconf=2.3]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=="+docs0fv_sparse_csv);
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+docs0fv_sparse_csv+"'");
 
     // Adding efi in transformer + rq should still use the transformer's params for feature extraction
     query.remove("fl");
     query.add("fl", "score,fvalias:[fv store=fstore2 efi.myconf=2.3]");
     query.add("rq", "{!ltr reRankDocs=3 model=externalmodel efi.user_query=w3}");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=="+docs0fv_sparse_csv);
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+docs0fv_sparse_csv+"'");
   }
 
   @Test
@@ -132,12 +129,10 @@ public class TestExternalFeatures extends TestRerankBase {
     query.setQuery("*:*");
     query.add("rows", "1");
 
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-
     // Efi is explicitly not required, so we do not score the feature
     query.remove("fl");
     query.add("fl", "fvalias:[fv store=fstore2]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore"+keyvalue_sep+"0.0'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("originalScore","0.0")+"'");
   }
 
   @Test
@@ -146,12 +141,10 @@ public class TestExternalFeatures extends TestRerankBase {
     query.setQuery("*:*");
     query.add("rows", "1");
 
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-
     // Efi is explicitly not required, so we do not score the feature
     query.remove("fl");
     query.add("fl", "fvalias:[fv store=fstore3]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore"+keyvalue_sep+"0.0'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("originalScore","0.0")+"'");
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
@@ -17,7 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.ltr.FeatureLogger;
+import org.apache.solr.ltr.FeatureLoggerTestUtils;
 import org.apache.solr.ltr.TestRerankBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -104,7 +104,7 @@ public class TestExternalFeatures extends TestRerankBase {
     query.setQuery("*:*");
     query.add("rows", "1");
 
-    final String docs0fv_sparse_csv = FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String docs0fv_sparse_csv = FeatureLoggerTestUtils.toFeatureVector(
         "confidence","2.3", "originalScore","1.0");
 
     // Features we're extracting depend on external feature info not passed in
@@ -132,7 +132,7 @@ public class TestExternalFeatures extends TestRerankBase {
     // Efi is explicitly not required, so we do not score the feature
     query.remove("fl");
     query.add("fl", "fvalias:[fv store=fstore2]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("originalScore","0.0")+"'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+FeatureLoggerTestUtils.toFeatureVector("originalScore","0.0")+"'");
   }
 
   @Test
@@ -144,7 +144,7 @@ public class TestExternalFeatures extends TestRerankBase {
     // Efi is explicitly not required, so we do not score the feature
     query.remove("fl");
     query.add("fl", "fvalias:[fv store=fstore3]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("originalScore","0.0")+"'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='"+FeatureLoggerTestUtils.toFeatureVector("originalScore","0.0")+"'");
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.FeatureLogger;
 import org.apache.solr.ltr.TestRerankBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -103,6 +104,12 @@ public class TestExternalFeatures extends TestRerankBase {
     query.setQuery("*:*");
     query.add("rows", "1");
 
+    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
+    final String docs0fv_sparse_csv = "'confidence"+csv_keyvalue_separator+"2.3"
+        + csv_value_delimiter + "originalScore"+csv_keyvalue_separator+"1.0'";
+
     // Features we're extracting depend on external feature info not passed in
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/error/msg=='Exception from createWeight for SolrFeature [name=matchedTitle, params={q={!terms f=title}${user_query}}] SolrFeatureWeight requires efi parameter that was not passed in request.'");
@@ -110,13 +117,13 @@ public class TestExternalFeatures extends TestRerankBase {
     // Adding efi in features section should make it work
     query.remove("fl");
     query.add("fl", "score,fvalias:[fv store=fstore2 efi.myconf=2.3]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='confidence:2.3;originalScore:1.0'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=="+docs0fv_sparse_csv);
 
     // Adding efi in transformer + rq should still use the transformer's params for feature extraction
     query.remove("fl");
     query.add("fl", "score,fvalias:[fv store=fstore2 efi.myconf=2.3]");
     query.add("rq", "{!ltr reRankDocs=3 model=externalmodel efi.user_query=w3}");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='confidence:2.3;originalScore:1.0'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=="+docs0fv_sparse_csv);
   }
 
   @Test
@@ -125,10 +132,12 @@ public class TestExternalFeatures extends TestRerankBase {
     query.setQuery("*:*");
     query.add("rows", "1");
 
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     // Efi is explicitly not required, so we do not score the feature
     query.remove("fl");
     query.add("fl", "fvalias:[fv store=fstore2]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore:0.0'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore"+keyvalue_sep+"0.0'");
   }
 
   @Test
@@ -137,10 +146,12 @@ public class TestExternalFeatures extends TestRerankBase {
     query.setQuery("*:*");
     query.add("rows", "1");
 
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     // Efi is explicitly not required, so we do not score the feature
     query.remove("fl");
     query.add("fl", "fvalias:[fv store=fstore3]");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore:0.0'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='originalScore"+keyvalue_sep+"0.0'");
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalValueFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalValueFeatures.java
@@ -59,11 +59,9 @@ public class TestExternalValueFeatures extends TestRerankBase {
     query.add("fl", "[fv]");
     query.add("rq", "{!ltr reRankDocs=3 model=external_model_binary_feature efi.user_device_tablet=1}");
 
-    final char features_keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/features=='user_device_tablet"+features_keyvalue_sep+"1.0'");
+        "/response/docs/[0]/features=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("user_device_tablet","1.0")+"'");
     assertJQ("/query" + query.toQueryString(),
         "/response/docs/[0]/score==65.0");
   }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalValueFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalValueFeatures.java
@@ -17,7 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.ltr.FeatureLogger;
+import org.apache.solr.ltr.FeatureLoggerTestUtils;
 import org.apache.solr.ltr.TestRerankBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -61,7 +61,7 @@ public class TestExternalValueFeatures extends TestRerankBase {
 
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/features=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("user_device_tablet","1.0")+"'");
+        "/response/docs/[0]/features=='"+FeatureLoggerTestUtils.toFeatureVector("user_device_tablet","1.0")+"'");
     assertJQ("/query" + query.toQueryString(),
         "/response/docs/[0]/score==65.0");
   }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalValueFeatures.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestExternalValueFeatures.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.FeatureLogger;
 import org.apache.solr.ltr.TestRerankBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -58,9 +59,11 @@ public class TestExternalValueFeatures extends TestRerankBase {
     query.add("fl", "[fv]");
     query.add("rq", "{!ltr reRankDocs=3 model=external_model_binary_feature efi.user_device_tablet=1}");
 
+    final char features_keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/features=='user_device_tablet:1.0'");
+        "/response/docs/[0]/features=='user_device_tablet"+features_keyvalue_sep+"1.0'");
     assertJQ("/query" + query.toQueryString(),
         "/response/docs/[0]/score==65.0");
   }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
@@ -56,14 +56,12 @@ public class TestFeatureLogging extends TestRerankBase {
         "c1", "c2", "c3"}, "test1",
         "{\"weights\":{\"c1\":1.0,\"c2\":1.0,\"c3\":1.0}}");
 
-    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
-
-    final String docs0fv_sparse_csv = "'c1"+csv_keyvalue_separator+"1.0"
-        + csv_value_delimiter + "c2"+csv_keyvalue_separator+"2.0"
-        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"3.0"
-        + csv_value_delimiter + "pop"+csv_keyvalue_separator+"2.0"
-        + csv_value_delimiter + "yesmatch"+csv_keyvalue_separator+"1.0'";
+    final String docs0fv_sparse_csv = FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "c1","1.0",
+        "c2","2.0",
+        "c3","3.0",
+        "pop","2.0",
+        "yesmatch","1.0");
 
     final SolrQuery query = new SolrQuery();
     query.setQuery("title:bloomberg");
@@ -75,7 +73,7 @@ public class TestFeatureLogging extends TestRerankBase {
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'title':'bloomberg bloomberg ', 'description':'bloomberg','id':'7', 'popularity':2,  '[fv]':"+docs0fv_sparse_csv+"}");
+        "/response/docs/[0]/=={'title':'bloomberg bloomberg ', 'description':'bloomberg','id':'7', 'popularity':2,  '[fv]':'"+docs0fv_sparse_csv+"'}");
 
     query.remove("fl");
     query.add("fl", "[fv]");
@@ -84,13 +82,13 @@ public class TestFeatureLogging extends TestRerankBase {
 
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'[fv]':"+docs0fv_sparse_csv+"}");
+        "/response/docs/[0]/=={'[fv]':'"+docs0fv_sparse_csv+"'}");
     query.remove("rq");
 
     // set logging at false but still asking for feature, and it should work anyway
     query.add("rq", "{!ltr reRankDocs=3 model=sum1}");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'[fv]':"+docs0fv_sparse_csv+"}");
+        "/response/docs/[0]/=={'[fv]':'"+docs0fv_sparse_csv+"'}");
 
 
   }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
@@ -17,7 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.ltr.FeatureLogger;
+import org.apache.solr.ltr.FeatureLoggerTestUtils;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.apache.solr.ltr.store.FeatureStore;
@@ -56,7 +56,7 @@ public class TestFeatureLogging extends TestRerankBase {
         "c1", "c2", "c3"}, "test1",
         "{\"weights\":{\"c1\":1.0,\"c2\":1.0,\"c3\":1.0}}");
 
-    final String docs0fv_sparse_csv = FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String docs0fv_sparse_csv = FeatureLoggerTestUtils.toFeatureVector(
         "c1","1.0",
         "c2","2.0",
         "c3","3.0",
@@ -116,24 +116,24 @@ public class TestFeatureLogging extends TestRerankBase {
     // No store specified, use default store for extraction
     query.add("fl", "fv:[fv]");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("defaultf1","1.0")+"'}");
+        "/response/docs/[0]/=={'fv':'"+FeatureLoggerTestUtils.toFeatureVector("defaultf1","1.0")+"'}");
 
     // Store specified, use store for extraction
     query.remove("fl");
     query.add("fl", "fv:[fv store=store8]");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("store8f1","2.0")+"'}");
+        "/response/docs/[0]/=={'fv':'"+FeatureLoggerTestUtils.toFeatureVector("store8f1","2.0")+"'}");
 
     // Store specified + model specified, use store for extraction
     query.add("rq", "{!ltr reRankDocs=3 model=store9m1}");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("store8f1","2.0")+"'}");
+        "/response/docs/[0]/=={'fv':'"+FeatureLoggerTestUtils.toFeatureVector("store8f1","2.0")+"'}");
 
     // No store specified + model specified, use model store for extraction
     query.remove("fl");
     query.add("fl", "fv:[fv]");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("store9f1","3.0")+"'}");
+        "/response/docs/[0]/=={'fv':'"+FeatureLoggerTestUtils.toFeatureVector("store9f1","3.0")+"'}");
   }
 
 
@@ -165,7 +165,7 @@ public class TestFeatureLogging extends TestRerankBase {
 
     query.add("rq", "{!ltr reRankDocs=3 model=sumgroup}");
 
-    final String docs0fv_sparse_csv = FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String docs0fv_sparse_csv = FeatureLoggerTestUtils.toFeatureVector(
         "c1","1.0",
         "c2","2.0",
         "c3","3.0",
@@ -203,11 +203,11 @@ public class TestFeatureLogging extends TestRerankBase {
         "match"}, "test4",
         "{\"weights\":{\"match\":1.0}}");
 
-    final String docs0fv_sparse_csv = FeatureLogger.CSVFeatureLogger.toFeatureVector("match", "1.0", "c4", "1.0");
-    final String docs1fv_sparse_csv = FeatureLogger.CSVFeatureLogger.toFeatureVector("c4", "1.0");
+    final String docs0fv_sparse_csv = FeatureLoggerTestUtils.toFeatureVector("match", "1.0", "c4", "1.0");
+    final String docs1fv_sparse_csv = FeatureLoggerTestUtils.toFeatureVector("c4", "1.0");
 
-    final String docs0fv_dense_csv  = FeatureLogger.CSVFeatureLogger.toFeatureVector("match", "1.0", "c4", "1.0");
-    final String docs1fv_dense_csv  = FeatureLogger.CSVFeatureLogger.toFeatureVector("match", "0.0", "c4", "1.0");
+    final String docs0fv_dense_csv  = FeatureLoggerTestUtils.toFeatureVector("match", "1.0", "c4", "1.0");
+    final String docs1fv_dense_csv  = FeatureLoggerTestUtils.toFeatureVector("match", "0.0", "c4", "1.0");
 
     final String docs0fv_sparse_json = "{'match':1.0,'c4':1.0}";
     final String docs1fv_sparse_json = "{'c4':1.0}";

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.FeatureLogger;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.apache.solr.ltr.store.FeatureStore;
@@ -55,6 +56,15 @@ public class TestFeatureLogging extends TestRerankBase {
         "c1", "c2", "c3"}, "test1",
         "{\"weights\":{\"c1\":1.0,\"c2\":1.0,\"c3\":1.0}}");
 
+    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
+    final String docs0fv_sparse_csv = "'c1"+csv_keyvalue_separator+"1.0"
+        + csv_value_delimiter + "c2"+csv_keyvalue_separator+"2.0"
+        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"3.0"
+        + csv_value_delimiter + "pop"+csv_keyvalue_separator+"2.0"
+        + csv_value_delimiter + "yesmatch"+csv_keyvalue_separator+"1.0'";
+
     final SolrQuery query = new SolrQuery();
     query.setQuery("title:bloomberg");
     query.add("fl", "title,description,id,popularity,[fv]");
@@ -65,7 +75,7 @@ public class TestFeatureLogging extends TestRerankBase {
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'title':'bloomberg bloomberg ', 'description':'bloomberg','id':'7', 'popularity':2,  '[fv]':'c1:1.0;c2:2.0;c3:3.0;pop:2.0;yesmatch:1.0'}");
+        "/response/docs/[0]/=={'title':'bloomberg bloomberg ', 'description':'bloomberg','id':'7', 'popularity':2,  '[fv]':"+docs0fv_sparse_csv+"}");
 
     query.remove("fl");
     query.add("fl", "[fv]");
@@ -74,13 +84,13 @@ public class TestFeatureLogging extends TestRerankBase {
 
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'[fv]':'c1:1.0;c2:2.0;c3:3.0;pop:2.0;yesmatch:1.0'}");
+        "/response/docs/[0]/=={'[fv]':"+docs0fv_sparse_csv+"}");
     query.remove("rq");
 
     // set logging at false but still asking for feature, and it should work anyway
     query.add("rq", "{!ltr reRankDocs=3 model=sum1}");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'[fv]':'c1:1.0;c2:2.0;c3:3.0;pop:2.0;yesmatch:1.0'}");
+        "/response/docs/[0]/=={'[fv]':"+docs0fv_sparse_csv+"}");
 
 
   }
@@ -101,6 +111,8 @@ public class TestFeatureLogging extends TestRerankBase {
       "store9",
       "{\"weights\":{\"store9f1\":1.0}}");
 
+    final char fv_keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     final SolrQuery query = new SolrQuery();
     query.setQuery("id:7");
     query.add("rows", "1");
@@ -108,24 +120,24 @@ public class TestFeatureLogging extends TestRerankBase {
     // No store specified, use default store for extraction
     query.add("fl", "fv:[fv]");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'defaultf1:1.0'}");
+        "/response/docs/[0]/=={'fv':'defaultf1"+fv_keyvalue_sep+"1.0'}");
 
     // Store specified, use store for extraction
     query.remove("fl");
     query.add("fl", "fv:[fv store=store8]");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'store8f1:2.0'}");
+        "/response/docs/[0]/=={'fv':'store8f1"+fv_keyvalue_sep+"2.0'}");
 
     // Store specified + model specified, use store for extraction
     query.add("rq", "{!ltr reRankDocs=3 model=store9m1}");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'store8f1:2.0'}");
+        "/response/docs/[0]/=={'fv':'store8f1"+fv_keyvalue_sep+"2.0'}");
 
     // No store specified + model specified, use model store for extraction
     query.remove("fl");
     query.add("fl", "fv:[fv]");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'fv':'store9f1:3.0'}");
+        "/response/docs/[0]/=={'fv':'store9f1"+fv_keyvalue_sep+"3.0'}");
   }
 
 
@@ -157,23 +169,32 @@ public class TestFeatureLogging extends TestRerankBase {
 
     query.add("rq", "{!ltr reRankDocs=3 model=sumgroup}");
 
+    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
+    final String docs0fv_sparse_csv = "'c1"+csv_keyvalue_separator+"1.0"
+        + csv_value_delimiter + "c2"+csv_keyvalue_separator+"2.0"
+        + csv_value_delimiter + "c3"+csv_keyvalue_separator+"3.0"
+        + csv_value_delimiter + "pop"+csv_keyvalue_separator+"5.0'";
+    final String docs0fv_sparse_json = "{'c1':1.0,'c2':2.0,'c3':3.0,'pop':5.0}";
+
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ(
         "/query" + query.toQueryString(),
-        "/grouped/title/groups/[0]/doclist/docs/[0]/=={'fv':'c1:1.0;c2:2.0;c3:3.0;pop:5.0'}");
+        "/grouped/title/groups/[0]/doclist/docs/[0]/=={'fv':"+docs0fv_sparse_csv+"}");
 
     query.remove("fl");
     query.add("fl", "fv:[fv fvwt=json]");
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ(
         "/query" + query.toQueryString(),
-        "/grouped/title/groups/[0]/doclist/docs/[0]/fv/=={'c1':1.0,'c2':2.0,'c3':3.0,'pop':5.0}");
+        "/grouped/title/groups/[0]/doclist/docs/[0]/fv/=="+docs0fv_sparse_json);
     query.remove("fl");
     query.add("fl", "fv:[fv fvwt=json]");
 
     assertJQ(
         "/query" + query.toQueryString(),
-        "/grouped/title/groups/[0]/doclist/docs/[0]/fv/=={'c1':1.0,'c2':2.0,'c3':3.0,'pop':5.0}");
+        "/grouped/title/groups/[0]/doclist/docs/[0]/fv/=="+docs0fv_sparse_json);
   }
 
   @Test
@@ -187,6 +208,21 @@ public class TestFeatureLogging extends TestRerankBase {
         "match"}, "test4",
         "{\"weights\":{\"match\":1.0}}");
 
+    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
+    final String docs0fv_sparse_csv = "'match"+csv_keyvalue_separator+"1.0"+csv_value_delimiter+"c4"+csv_keyvalue_separator+"1.0'";
+    final String docs1fv_sparse_csv = "'c4"   +csv_keyvalue_separator+"1.0'";
+
+    final String docs0fv_dense_csv  = "'match"+csv_keyvalue_separator+"1.0"+csv_value_delimiter+"c4"+csv_keyvalue_separator+"1.0'";
+    final String docs1fv_dense_csv  = "'match"+csv_keyvalue_separator+"0.0"+csv_value_delimiter+"c4"+csv_keyvalue_separator+"1.0'";
+
+    final String docs0fv_sparse_json = "{'match':1.0,'c4':1.0}";
+    final String docs1fv_sparse_json = "{'c4':1.0}";
+
+    final String docs0fv_dense_json  = "{'match':1.0,'c4':1.0}";
+    final String docs1fv_dense_json  = "{'match':0.0,'c4':1.0}";
+
     //json - no feature format check (default to sparse)
     final SolrQuery query = new SolrQuery();
     query.setQuery("title:bloomberg");
@@ -195,60 +231,60 @@ public class TestFeatureLogging extends TestRerankBase {
     query.add("rq", "{!ltr reRankDocs=10 model=sum4}");
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/fv/=={'match':1.0,'c4':1.0}");
+        "/response/docs/[0]/fv/=="+docs0fv_sparse_json);
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[1]/fv/=={'c4':1.0}");
+        "/response/docs/[1]/fv/=="+docs1fv_sparse_json);
 
     //json - sparse feature format check
     query.remove("fl");
     query.add("fl", "*,score,fv:[fv store=test4 format=sparse fvwt=json]");
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/fv/=={'match':1.0,'c4':1.0}");
+        "/response/docs/[0]/fv/=="+docs0fv_sparse_json);
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[1]/fv/=={'c4':1.0}");
+        "/response/docs/[1]/fv/=="+docs1fv_sparse_json);
 
     //json - dense feature format check
     query.remove("fl");
     query.add("fl", "*,score,fv:[fv store=test4 format=dense fvwt=json]");
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/fv/=={'match':1.0,'c4':1.0}");
+        "/response/docs/[0]/fv/=="+docs0fv_dense_json);
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[1]/fv/=={'match':0.0,'c4':1.0}");
+        "/response/docs/[1]/fv/=="+docs1fv_dense_json);
 
     //csv - no feature format check (default to sparse)
     query.remove("fl");
     query.add("fl", "*,score,fv:[fv store=test4 fvwt=csv]");
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/fv/=='match:1.0;c4:1.0'");
+        "/response/docs/[0]/fv/=="+docs0fv_sparse_csv);
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[1]/fv/=='c4:1.0'");
+        "/response/docs/[1]/fv/=="+docs1fv_sparse_csv);
 
     //csv - sparse feature format check
     query.remove("fl");
     query.add("fl", "*,score,fv:[fv store=test4 format=sparse fvwt=csv]");
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/fv/=='match:1.0;c4:1.0'");
+        "/response/docs/[0]/fv/=="+docs0fv_sparse_csv);
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[1]/fv/=='c4:1.0'");
+        "/response/docs/[1]/fv/=="+docs1fv_sparse_csv);
 
     //csv - dense feature format check
     query.remove("fl");
     query.add("fl", "*,score,fv:[fv store=test4 format=dense fvwt=csv]");
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/fv/=='match:1.0;c4:1.0'");
+        "/response/docs/[0]/fv/=="+docs0fv_dense_csv);
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[1]/fv/=='match:0.0;c4:1.0'");
+        "/response/docs/[1]/fv/=="+docs1fv_dense_csv);
   }
 
 }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFieldValueFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFieldValueFeature.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.FeatureLogger;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.junit.AfterClass;
@@ -103,6 +104,8 @@ public class TestFieldValueFeature extends TestRerankBase {
 
   @Test
   public void testIfADocumentDoesntHaveAFieldDefaultValueIsReturned() throws Exception {
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     SolrQuery query = new SolrQuery();
     query.setQuery("id:42");
     query.add("fl", "*, score");
@@ -116,7 +119,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'popularity:"+FIELD_VALUE_FEATURE_DEFAULT_VAL+"'}");
+            "/response/docs/[0]/=={'[fv]':'popularity"+keyvalue_sep+FIELD_VALUE_FEATURE_DEFAULT_VAL+"'}");
 
   }
 
@@ -128,6 +131,8 @@ public class TestFieldValueFeature extends TestRerankBase {
 
     loadFeature("popularity42", FieldValueFeature.class.getCanonicalName(), fstore,
             "{\"field\":\"popularity\",\"defaultValue\":\"42.0\"}");
+
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
 
     SolrQuery query = new SolrQuery();
     query.setQuery("id:42");
@@ -145,7 +150,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'popularity42:42.0'}");
+            "/response/docs/[0]/=={'[fv]':'popularity42"+keyvalue_sep+"42.0'}");
 
   }
 
@@ -159,13 +164,15 @@ public class TestFieldValueFeature extends TestRerankBase {
     loadModel("not-existing-field-model", LinearModel.class.getCanonicalName(),
             new String[] {"not-existing-field"}, fstore, "{\"weights\":{\"not-existing-field\":1.0}}");
 
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     final SolrQuery query = new SolrQuery();
     query.setQuery("id:42");
     query.add("rq", "{!ltr model=not-existing-field-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'not-existing-field:"+FIELD_VALUE_FEATURE_DEFAULT_VAL+"'}");
+            "/response/docs/[0]/=={'[fv]':'not-existing-field"+keyvalue_sep+FIELD_VALUE_FEATURE_DEFAULT_VAL+"'}");
 
   }
 
@@ -178,12 +185,14 @@ public class TestFieldValueFeature extends TestRerankBase {
     loadModel("trendy-model", LinearModel.class.getCanonicalName(),
             new String[] {"trendy"}, fstore, "{\"weights\":{\"trendy\":1.0}}");
 
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     SolrQuery query = new SolrQuery();
     query.setQuery("id:4");
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'trendy:0.0'}");
+            "/response/docs/[0]/=={'[fv]':'trendy"+keyvalue_sep+"0.0'}");
 
 
     query = new SolrQuery();
@@ -191,7 +200,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'trendy:1.0'}");
+            "/response/docs/[0]/=={'[fv]':'trendy"+keyvalue_sep+"1.0'}");
 
     // check default value is false
     query = new SolrQuery();
@@ -199,7 +208,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'trendy:0.0'}");
+            "/response/docs/[0]/=={'[fv]':'trendy"+keyvalue_sep+"0.0'}");
 
   }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFieldValueFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFieldValueFeature.java
@@ -17,7 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.ltr.FeatureLogger;
+import org.apache.solr.ltr.FeatureLoggerTestUtils;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.junit.AfterClass;
@@ -118,7 +118,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("popularity",Float.toString(FIELD_VALUE_FEATURE_DEFAULT_VAL))+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLoggerTestUtils.toFeatureVector("popularity",Float.toString(FIELD_VALUE_FEATURE_DEFAULT_VAL))+"'}");
 
   }
 
@@ -147,7 +147,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("popularity42","42.0")+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLoggerTestUtils.toFeatureVector("popularity42","42.0")+"'}");
 
   }
 
@@ -167,7 +167,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("not-existing-field",Float.toString(FIELD_VALUE_FEATURE_DEFAULT_VAL))+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLoggerTestUtils.toFeatureVector("not-existing-field",Float.toString(FIELD_VALUE_FEATURE_DEFAULT_VAL))+"'}");
 
   }
 
@@ -185,7 +185,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("trendy","0.0")+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLoggerTestUtils.toFeatureVector("trendy","0.0")+"'}");
 
 
     query = new SolrQuery();
@@ -193,7 +193,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("trendy","1.0")+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLoggerTestUtils.toFeatureVector("trendy","1.0")+"'}");
 
     // check default value is false
     query = new SolrQuery();
@@ -201,7 +201,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("trendy","0.0")+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLoggerTestUtils.toFeatureVector("trendy","0.0")+"'}");
 
   }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFieldValueFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFieldValueFeature.java
@@ -104,7 +104,6 @@ public class TestFieldValueFeature extends TestRerankBase {
 
   @Test
   public void testIfADocumentDoesntHaveAFieldDefaultValueIsReturned() throws Exception {
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
 
     SolrQuery query = new SolrQuery();
     query.setQuery("id:42");
@@ -119,7 +118,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'popularity"+keyvalue_sep+FIELD_VALUE_FEATURE_DEFAULT_VAL+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("popularity",Float.toString(FIELD_VALUE_FEATURE_DEFAULT_VAL))+"'}");
 
   }
 
@@ -131,8 +130,6 @@ public class TestFieldValueFeature extends TestRerankBase {
 
     loadFeature("popularity42", FieldValueFeature.class.getCanonicalName(), fstore,
             "{\"field\":\"popularity\",\"defaultValue\":\"42.0\"}");
-
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
 
     SolrQuery query = new SolrQuery();
     query.setQuery("id:42");
@@ -150,7 +147,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'popularity42"+keyvalue_sep+"42.0'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("popularity42","42.0")+"'}");
 
   }
 
@@ -164,15 +161,13 @@ public class TestFieldValueFeature extends TestRerankBase {
     loadModel("not-existing-field-model", LinearModel.class.getCanonicalName(),
             new String[] {"not-existing-field"}, fstore, "{\"weights\":{\"not-existing-field\":1.0}}");
 
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-
     final SolrQuery query = new SolrQuery();
     query.setQuery("id:42");
     query.add("rq", "{!ltr model=not-existing-field-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==1");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'not-existing-field"+keyvalue_sep+FIELD_VALUE_FEATURE_DEFAULT_VAL+"'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("not-existing-field",Float.toString(FIELD_VALUE_FEATURE_DEFAULT_VAL))+"'}");
 
   }
 
@@ -185,14 +180,12 @@ public class TestFieldValueFeature extends TestRerankBase {
     loadModel("trendy-model", LinearModel.class.getCanonicalName(),
             new String[] {"trendy"}, fstore, "{\"weights\":{\"trendy\":1.0}}");
 
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-
     SolrQuery query = new SolrQuery();
     query.setQuery("id:4");
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'trendy"+keyvalue_sep+"0.0'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("trendy","0.0")+"'}");
 
 
     query = new SolrQuery();
@@ -200,7 +193,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'trendy"+keyvalue_sep+"1.0'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("trendy","1.0")+"'}");
 
     // check default value is false
     query = new SolrQuery();
@@ -208,7 +201,7 @@ public class TestFieldValueFeature extends TestRerankBase {
     query.add("rq", "{!ltr model=trendy-model reRankDocs=4}");
     query.add("fl", "[fv]");
     assertJQ("/query" + query.toQueryString(),
-            "/response/docs/[0]/=={'[fv]':'trendy"+keyvalue_sep+"0.0'}");
+            "/response/docs/[0]/=={'[fv]':'"+FeatureLogger.CSVFeatureLogger.toFeatureVector("trendy","0.0")+"'}");
 
   }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFilterSolrFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFilterSolrFeature.java
@@ -17,7 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.ltr.FeatureLogger;
+import org.apache.solr.ltr.FeatureLoggerTestUtils;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.apache.solr.ltr.store.rest.ManagedFeatureStore;
@@ -97,7 +97,7 @@ public class TestFilterSolrFeature extends TestRerankBase {
     query.add("rq", "{!ltr reRankDocs=4 model=fqmodel efi.user_query=w2}");
     query.add("fl", "fv:[fv]");
 
-    final String docs0fv_sparse_csv= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+    final String docs0fv_sparse_csv= FeatureLoggerTestUtils.toFeatureVector(
         "matchedTitle","1.0", "popularity","3.0");
 
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='2'");

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFilterSolrFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFilterSolrFeature.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr.feature;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.FeatureLogger;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.apache.solr.ltr.store.rest.ManagedFeatureStore;
@@ -96,10 +97,16 @@ public class TestFilterSolrFeature extends TestRerankBase {
     query.add("rq", "{!ltr reRankDocs=4 model=fqmodel efi.user_query=w2}");
     query.add("fl", "fv:[fv]");
 
+    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
+    final String docs0fv_sparse_csv = "'matchedTitle"+csv_keyvalue_separator+"1.0"
+        + csv_value_delimiter + "popularity"+csv_keyvalue_separator+"3.0'";
+
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='2'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='3'");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='matchedTitle:1.0;popularity:3.0'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv_sparse_csv);
   }
 
 }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFilterSolrFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestFilterSolrFeature.java
@@ -97,16 +97,13 @@ public class TestFilterSolrFeature extends TestRerankBase {
     query.add("rq", "{!ltr reRankDocs=4 model=fqmodel efi.user_query=w2}");
     query.add("fl", "fv:[fv]");
 
-    final char csv_keyvalue_separator = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-    final char csv_value_delimiter = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
-
-    final String docs0fv_sparse_csv = "'matchedTitle"+csv_keyvalue_separator+"1.0"
-        + csv_value_delimiter + "popularity"+csv_keyvalue_separator+"3.0'";
+    final String docs0fv_sparse_csv= FeatureLogger.CSVFeatureLogger.toFeatureVector(
+        "matchedTitle","1.0", "popularity","3.0");
 
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='2'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='3'");
-    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=="+docs0fv_sparse_csv);
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fv=='"+docs0fv_sparse_csv+"'");
   }
 
 }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
@@ -105,13 +105,11 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
     final Double doc0Score = (Double) ((Map<String,Object>) ((ArrayList<Object>) ((Map<String,Object>) jsonParse
         .get("response")).get("docs")).get(0)).get("score");
 
-    final char fv_keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score=="
         + (doc0Score * 1.1));
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='yesmatchfeature"+fv_keyvalue_sep + doc0Score + "'");
+        "/response/docs/[0]/fv=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("yesmatchfeature", doc0Score.toString())+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='2'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/score==0.0");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/fv==''");
@@ -144,11 +142,9 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
     final Double doc0Score = (Double) ((Map<String,Object>) ((ArrayList<Object>) ((Map<String,Object>) jsonParse
         .get("response")).get("docs")).get(0)).get("score");
 
-    final char fv_keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==0.0");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='yesmatchfeature"+fv_keyvalue_sep + doc0Score + "'");
+        "/response/docs/[0]/fv=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("yesmatchfeature", doc0Score.toString())+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/score==0.0");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/fv==''");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/score==0.0");

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.ltr.FeatureLogger;
+import org.apache.solr.ltr.FeatureLoggerTestUtils;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.apache.solr.ltr.model.MultipleAdditiveTreesModel;
@@ -109,7 +109,7 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score=="
         + (doc0Score * 1.1));
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("yesmatchfeature", doc0Score.toString())+"'");
+        "/response/docs/[0]/fv=='"+FeatureLoggerTestUtils.toFeatureVector("yesmatchfeature", doc0Score.toString())+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='2'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/score==0.0");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/fv==''");
@@ -144,7 +144,7 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
 
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==0.0");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='"+FeatureLogger.CSVFeatureLogger.toFeatureVector("yesmatchfeature", doc0Score.toString())+"'");
+        "/response/docs/[0]/fv=='"+FeatureLoggerTestUtils.toFeatureVector("yesmatchfeature", doc0Score.toString())+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/score==0.0");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/fv==''");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/score==0.0");

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.FeatureLogger;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.apache.solr.ltr.model.MultipleAdditiveTreesModel;
@@ -104,12 +105,13 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
     final Double doc0Score = (Double) ((Map<String,Object>) ((ArrayList<Object>) ((Map<String,Object>) jsonParse
         .get("response")).get("docs")).get(0)).get("score");
 
+    final char fv_keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
 
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score=="
         + (doc0Score * 1.1));
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='yesmatchfeature:" + doc0Score + "'");
+        "/response/docs/[0]/fv=='yesmatchfeature"+fv_keyvalue_sep + doc0Score + "'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='2'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/score==0.0");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/fv==''");
@@ -142,9 +144,11 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
     final Double doc0Score = (Double) ((Map<String,Object>) ((ArrayList<Object>) ((Map<String,Object>) jsonParse
         .get("response")).get("docs")).get(0)).get("score");
 
+    final char fv_keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==0.0");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='yesmatchfeature:" + doc0Score + "'");
+        "/response/docs/[0]/fv=='yesmatchfeature"+fv_keyvalue_sep + doc0Score + "'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/score==0.0");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/fv==''");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/score==0.0");

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestOriginalScoreFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestOriginalScoreFeature.java
@@ -130,23 +130,20 @@ public class TestOriginalScoreFeature extends TestRerankBase {
     final String doc3Score = ((Double) ((Map<String,Object>) ((ArrayList<Object>) ((Map<String,Object>) jsonParse
         .get("response")).get("docs")).get(3)).get("score")).toString();
 
-    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
-    final char value_delim = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
-
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==4");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='origScore" + keyvalue_sep + doc0Score + value_delim + "c2"+keyvalue_sep+"2.0'");
+        "/response/docs/[0]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc0Score, "c2", "2.0")+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='8'");
 
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[1]/fv=='origScore" + keyvalue_sep + doc1Score + value_delim + "c2"+keyvalue_sep+"2.0'");
+        "/response/docs/[1]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc1Score, "c2", "2.0")+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='6'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[2]/fv=='origScore" + keyvalue_sep + doc2Score + value_delim + "c2"+keyvalue_sep+"2.0'");
+        "/response/docs/[2]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc2Score, "c2", "2.0")+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[3]/id=='7'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[3]/fv=='origScore" + keyvalue_sep + doc3Score + value_delim + "c2"+keyvalue_sep+"2.0'");
+        "/response/docs/[3]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc3Score, "c2", "2.0")+"'");
   }
 
 }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestOriginalScoreFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestOriginalScoreFeature.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.ltr.FeatureLogger;
+import org.apache.solr.ltr.FeatureLoggerTestUtils;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.junit.AfterClass;
@@ -133,17 +133,17 @@ public class TestOriginalScoreFeature extends TestRerankBase {
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==4");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc0Score, "c2", "2.0")+"'");
+        "/response/docs/[0]/fv=='" + FeatureLoggerTestUtils.toFeatureVector("origScore", doc0Score, "c2", "2.0")+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='8'");
 
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[1]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc1Score, "c2", "2.0")+"'");
+        "/response/docs/[1]/fv=='" + FeatureLoggerTestUtils.toFeatureVector("origScore", doc1Score, "c2", "2.0")+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='6'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[2]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc2Score, "c2", "2.0")+"'");
+        "/response/docs/[2]/fv=='" + FeatureLoggerTestUtils.toFeatureVector("origScore", doc2Score, "c2", "2.0")+"'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[3]/id=='7'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[3]/fv=='" + FeatureLogger.CSVFeatureLogger.toFeatureVector("origScore", doc3Score, "c2", "2.0")+"'");
+        "/response/docs/[3]/fv=='" + FeatureLoggerTestUtils.toFeatureVector("origScore", doc3Score, "c2", "2.0")+"'");
   }
 
 }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestOriginalScoreFeature.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/feature/TestOriginalScoreFeature.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.ltr.FeatureLogger;
 import org.apache.solr.ltr.TestRerankBase;
 import org.apache.solr.ltr.model.LinearModel;
 import org.junit.AfterClass;
@@ -129,20 +130,23 @@ public class TestOriginalScoreFeature extends TestRerankBase {
     final String doc3Score = ((Double) ((Map<String,Object>) ((ArrayList<Object>) ((Map<String,Object>) jsonParse
         .get("response")).get("docs")).get(3)).get("score")).toString();
 
+    final char keyvalue_sep = FeatureLogger.CSVFeatureLogger.DEFAULT_KEY_VALUE_SEPARATOR;
+    final char value_delim = FeatureLogger.CSVFeatureLogger.DEFAULT_FEATURE_SEPARATOR;
+
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==4");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[0]/fv=='origScore:" + doc0Score + ";c2:2.0'");
+        "/response/docs/[0]/fv=='origScore" + keyvalue_sep + doc0Score + value_delim + "c2"+keyvalue_sep+"2.0'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='8'");
 
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[1]/fv=='origScore:" + doc1Score + ";c2:2.0'");
+        "/response/docs/[1]/fv=='origScore" + keyvalue_sep + doc1Score + value_delim + "c2"+keyvalue_sep+"2.0'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='6'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[2]/fv=='origScore:" + doc2Score + ";c2:2.0'");
+        "/response/docs/[2]/fv=='origScore" + keyvalue_sep + doc2Score + value_delim + "c2"+keyvalue_sep+"2.0'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[3]/id=='7'");
     assertJQ("/query" + query.toQueryString(),
-        "/response/docs/[3]/fv=='origScore:" + doc3Score + ";c2:2.0'");
+        "/response/docs/[3]/fv=='origScore" + keyvalue_sep + doc3Score + value_delim + "c2"+keyvalue_sep+"2.0'");
   }
 
 }


### PR DESCRIPTION

(as preparation for changing the CSV to use comma (not semicolon) as separator)