### PR TITLE
make CSVFeatureLogger's delimiter comma (instead of semicolon)

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
@@ -151,8 +151,8 @@ public abstract class FeatureLogger<FV_TYPE> {
   }
 
   public static class CSVFeatureLogger extends FeatureLogger<String> {
-    static final char DEFAULT_KEY_VALUE_SEPARATOR = ':';
-    static final char DEFAULT_FEATURE_SEPARATOR = ';';
+    static final char DEFAULT_KEY_VALUE_SEPARATOR = '=';
+    static final char DEFAULT_FEATURE_SEPARATOR = ',';
     char keyValueSep = DEFAULT_KEY_VALUE_SEPARATOR;
     char featureSep = DEFAULT_FEATURE_SEPARATOR;
 


### PR DESCRIPTION
also change key-value separator from : to = so that it's more distinct from JSON feature logging