### PR TITLE
add SearchGroupsContainer

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -98,6 +98,7 @@ import org.apache.solr.search.grouping.distributed.requestfactory.SearchGroupsRe
 import org.apache.solr.search.grouping.distributed.requestfactory.StoredFieldsShardRequestFactory;
 import org.apache.solr.search.grouping.distributed.requestfactory.TopGroupsShardRequestFactory;
 import org.apache.solr.search.grouping.distributed.responseprocessor.SearchGroupShardResponseProcessor;
+import org.apache.solr.search.grouping.distributed.responseprocessor.SkipSecondStepSearchGroupShardResponseProcessor;
 import org.apache.solr.search.grouping.distributed.responseprocessor.StoredFieldsShardResponseProcessor;
 import org.apache.solr.search.grouping.distributed.responseprocessor.TopGroupsShardResponseProcessor;
 import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer;
@@ -617,10 +618,18 @@ public class QueryComponent extends SearchComponent
     }
   }
 
+  protected SearchGroupShardResponseProcessor newSearchGroupShardResponseProcessor(ResponseBuilder rb) {
+    if (rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+      return new SkipSecondStepSearchGroupShardResponseProcessor();
+    } else {
+      return new SearchGroupShardResponseProcessor();
+    }
+  }
+
   protected void handleGroupedResponses(ResponseBuilder rb, ShardRequest sreq) {
     ShardResponseProcessor responseProcessor = null;
     if ((sreq.purpose & ShardRequest.PURPOSE_GET_TOP_GROUPS) != 0) {
-      responseProcessor = new SearchGroupShardResponseProcessor();
+      responseProcessor = newSearchGroupShardResponseProcessor(rb);
     } else if ((sreq.purpose & ShardRequest.PURPOSE_GET_TOP_IDS) != 0) {
       responseProcessor = new TopGroupsShardResponseProcessor();
     } else if ((sreq.purpose & ShardRequest.PURPOSE_GET_FIELDS) != 0) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -1322,6 +1322,14 @@ public class QueryComponent extends SearchComponent
     return true;
   }
 
+  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(ResponseBuilder rb, SolrIndexSearcher searcher) {
+    if (rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+      return new SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer(searcher);
+    } else {
+      return new SearchGroupsResultTransformer.DefaultSearchResultResultTransformer(searcher);
+    }
+  }
+
   private void doProcessGroupedDistributedSearchFirstPhase(ResponseBuilder rb, QueryCommand cmd, QueryResult result) throws IOException {
 
     GroupingSpecification groupingSpec = rb.getGroupingSpec();
@@ -1351,7 +1359,7 @@ public class QueryComponent extends SearchComponent
 
     CommandHandler commandHandler = topsGroupsActionBuilder.build();
     commandHandler.execute();
-    SearchGroupsResultTransformer serializer = SearchGroupsResultTransformer.getInstance(searcher, rb.getGroupingSpec().isSkipSecondGroupingStep());
+    SearchGroupsResultTransformer serializer = newSearchGroupsResultTransformer(rb, searcher);
 
     rsp.add("firstPhase", commandHandler.processResult(result, serializer));
     rsp.add("totalHitCount", commandHandler.getTotalHitCount());

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -49,7 +49,7 @@ import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchG
 public class SearchGroupShardResponseProcessor implements ShardResponseProcessor {
 
   protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(SolrIndexSearcher solrIndexSearcher) {
-    return SearchGroupsResultTransformer.getInstance(solrIndexSearcher, false);
+    return new SearchGroupsResultTransformer.DefaultSearchResultResultTransformer(solrIndexSearcher);
   }
 
   protected SearchGroupsContainer newSearchGroupsContainer(ResponseBuilder rb) {

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -27,20 +27,17 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.search.grouping.GroupDocs;
 import org.apache.lucene.search.grouping.SearchGroup;
-import org.apache.lucene.search.grouping.TopGroups;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.handler.component.ResponseBuilder;
-import org.apache.solr.handler.component.ShardDoc;
 import org.apache.solr.handler.component.ShardRequest;
 import org.apache.solr.handler.component.ShardResponse;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.SortSpec;
 import org.apache.solr.search.grouping.distributed.ShardResponseProcessor;
 import org.apache.solr.search.grouping.distributed.command.SearchGroupsFieldCommandResult;
@@ -51,6 +48,14 @@ import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchG
  */
 public class SearchGroupShardResponseProcessor implements ShardResponseProcessor {
 
+  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(SolrIndexSearcher solrIndexSearcher) {
+    return SearchGroupsResultTransformer.getInstance(solrIndexSearcher, false);
+  }
+
+  protected SearchGroupsContainer newSearchGroupsContainer(ResponseBuilder rb) {
+      return new SearchGroupsContainer(rb.getGroupingSpec().getFields());
+  }
+
   @Override
   public void process(ResponseBuilder rb, ShardRequest shardRequest) {
     SortSpec groupSortSpec = rb.getGroupingSpec().getGroupSortSpec();
@@ -60,18 +65,14 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
     assert withinGroupSort != null;
 
     final Map<String, List<Collection<SearchGroup<BytesRef>>>> commandSearchGroups = new HashMap<>(fields.length, 1.0f);
-    final Map<String, Map<SearchGroup<BytesRef>, Set<String>>> tempSearchGroupToShards = new HashMap<>(fields.length, 1.0f);
     for (String field : fields) {
       commandSearchGroups.put(field, new ArrayList<Collection<SearchGroup<BytesRef>>>(shardRequest.responses.size()));
-      tempSearchGroupToShards.put(field, new HashMap<SearchGroup<BytesRef>, Set<String>>());
       if (!rb.searchGroupToShards.containsKey(field)) {
         rb.searchGroupToShards.put(field, new HashMap<SearchGroup<BytesRef>, Set<String>>());
       }
     }
 
-    final SearchGroupsResultTransformer serializer = SearchGroupsResultTransformer.getInstance(rb.req.getSearcher(), rb.getGroupingSpec().isSkipSecondGroupingStep());
-    final Map<Object, String> docIdToShard = new HashMap<>();
-
+    SearchGroupsResultTransformer serializer = newSearchGroupsResultTransformer(rb.req.getSearcher());
     int maxElapsedTime = 0;
     int hitCountDuringFirstPhase = 0;
 
@@ -80,6 +81,8 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       shardInfo = new SimpleOrderedMap<>(shardRequest.responses.size());
       rb.rsp.getValues().add(ShardParams.SHARDS_INFO + ".firstPhase", shardInfo);
     }
+
+    SearchGroupsContainer searchGroupsContainer = newSearchGroupsContainer(rb);
 
     for (ShardResponse srsp : shardRequest.responses) {
       if (shardInfo != null) {
@@ -129,17 +132,7 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
         }
 
         commandSearchGroups.get(field).add(searchGroups);
-        for (SearchGroup<BytesRef> searchGroup : searchGroups) {
-          Map<SearchGroup<BytesRef>, Set<String>> map = tempSearchGroupToShards.get(field);
-          Set<String> shards = map.get(searchGroup);
-          if (shards == null) {
-            shards = new HashSet<>();
-            map.put(searchGroup, shards);
-          }
-          assert(srsp.getShard() != null);
-          docIdToShard.put(searchGroup.topDocSolrId, srsp.getShard());
-          shards.add(srsp.getShard());
-        }
+        searchGroupsContainer.addSearchGroups(srsp, field, searchGroups);
       }
       hitCountDuringFirstPhase += (Integer) srsp.getSolrResponse().getResponse().get("totalHitCount");
     }
@@ -151,61 +144,43 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       if (mergedTopGroups == null) {
         continue;
       }
-      if (rb.getGroupingSpec().isSkipSecondGroupingStep()){
-          /* If we are skipping the second grouping step we want to translate the response of the
-           * first step in the response of the second step and send it to the get_fields step.
-           */
-          processSkipSecondGroupingStep(rb, mergedTopGroups, tempSearchGroupToShards, docIdToShard, groupSort, fields,  groupField);
-      }
-      else {
-        rb.mergedSearchGroups.put(groupField, mergedTopGroups);
-        for (SearchGroup<BytesRef> mergedTopGroup : mergedTopGroups) {
-          rb.searchGroupToShards.get(groupField).put(mergedTopGroup, tempSearchGroupToShards.get(groupField).get(mergedTopGroup));
-        }
-      }
+      searchGroupsContainer.addMergedSearchGroups(rb, groupField, mergedTopGroups);
+      searchGroupsContainer.addSearchGroupToShards(rb, groupField, mergedTopGroups);
     }
   }
 
-  private void processSkipSecondGroupingStep(final ResponseBuilder rb, final Collection<SearchGroup<BytesRef>> mergedTopGroups, final Map<String, Map<SearchGroup<BytesRef>, Set<String>>> tempSearchGroupToShards, Map<Object, String> docIdToShard, Sort groupSort, final String[] fields, final String groupField){
-    GroupDocs<BytesRef>[] groups = new GroupDocs[mergedTopGroups.size()];
-    Map<Object, ShardDoc> resultsId = new HashMap<>(mergedTopGroups.size());
+  protected static class SearchGroupsContainer {
 
-    // This is the max score found in any document on any group
-    float maxScore = 0;
-    int index = 0;
+    private final Map<String, Map<SearchGroup<BytesRef>, Set<String>>> tempSearchGroupToShards;
 
-    for (SearchGroup<BytesRef> group : mergedTopGroups) {
-      maxScore = Math.max(maxScore, group.topDocScore);
-      rb.searchGroupToShards.get(groupField).put(group, tempSearchGroupToShards.get(groupField).get(group));
-      final String shard = docIdToShard.get(group.topDocSolrId);
-      assert(shard != null);
-      ShardDoc sdoc = new ShardDoc(group.topDocScore,
-          fields,
-          group.topDocSolrId,
-          shard );
-      sdoc.positionInResponse = index;
-
-      resultsId.put(sdoc.id, sdoc);
-      groups[index++] = new GroupDocs<BytesRef>(group.topDocScore,
-          group.topDocScore,
-          new TotalHits(1, TotalHits.Relation.EQUAL_TO), /* we don't know the actual number of hits in the group- we set it to 1 as we only keep track of the top doc */
-          new ShardDoc[] { sdoc }, /* only top doc */
-          group.groupValue,
-          group.sortValues);
-    }
-    TopGroups<BytesRef> topMergedGroups = new TopGroups<BytesRef>(groupSort.getSort(),
-        rb.getGroupingSpec().getSortWithinGroup().getSort(),
-        0, /*Set totalHitCount to 0 as we can't computed it as is */
-        0, /*Set totalGroupedHitCount to 0 as we can't computed it as is*/
-        groups,
-        maxScore);
-    rb.mergedTopGroups.put(groupField, topMergedGroups);
-
-    if(rb.resultIds == null) {
-      rb.resultIds = new HashMap<>();
+    public SearchGroupsContainer(String[] fields) {
+      tempSearchGroupToShards = new HashMap<>(fields.length, 1.0f);
+      for (String field : fields) {
+        tempSearchGroupToShards.put(field, new HashMap<SearchGroup<BytesRef>, Set<String>>());
+      }
     }
 
-    rb.resultIds.putAll(resultsId);
+    public void addSearchGroups(ShardResponse srsp, String field, Collection<SearchGroup<BytesRef>> searchGroups) {
+      for (SearchGroup<BytesRef> searchGroup : searchGroups) {
+        Map<SearchGroup<BytesRef>, Set<String>> map = tempSearchGroupToShards.get(field);
+        Set<String> shards = map.get(searchGroup);
+        if (shards == null) {
+          shards = new HashSet<>();
+          map.put(searchGroup, shards);
+        }
+        shards.add(srsp.getShard());
+      }
+    }
+
+    public void addMergedSearchGroups(ResponseBuilder rb, String groupField, Collection<SearchGroup<BytesRef>> mergedTopGroups) {
+      rb.mergedSearchGroups.put(groupField, mergedTopGroups);
+    }
+
+    public void addSearchGroupToShards(ResponseBuilder rb, String groupField, Collection<SearchGroup<BytesRef>> mergedTopGroups) {
+      for (SearchGroup<BytesRef> mergedTopGroup : mergedTopGroups) {
+        rb.searchGroupToShards.get(groupField).put(mergedTopGroup, tempSearchGroupToShards.get(groupField).get(mergedTopGroup));
+      }
+    }
   }
 
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
@@ -32,12 +32,13 @@ import org.apache.solr.handler.component.ShardResponse;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.grouping.GroupingSpecification;
 import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer;
+import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer;
 
 public class SkipSecondStepSearchGroupShardResponseProcessor extends SearchGroupShardResponseProcessor {
 
   @Override
   protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(SolrIndexSearcher solrIndexSearcher) {
-    return SearchGroupsResultTransformer.getInstance(solrIndexSearcher, true);
+    return new SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer(solrIndexSearcher);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.grouping.distributed.responseprocessor;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.grouping.GroupDocs;
+import org.apache.lucene.search.grouping.SearchGroup;
+import org.apache.lucene.search.grouping.TopGroups;
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardDoc;
+import org.apache.solr.handler.component.ShardResponse;
+import org.apache.solr.search.SolrIndexSearcher;
+import org.apache.solr.search.grouping.GroupingSpecification;
+import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer;
+
+public class SkipSecondStepSearchGroupShardResponseProcessor extends SearchGroupShardResponseProcessor {
+
+  @Override
+  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(SolrIndexSearcher solrIndexSearcher) {
+    return SearchGroupsResultTransformer.getInstance(solrIndexSearcher, true);
+  }
+
+  @Override
+  protected SearchGroupsContainer newSearchGroupsContainer(ResponseBuilder rb) {
+    return new SkipSecondStepSearchGroupsContainer(rb.getGroupingSpec().getFields());
+  }
+
+  protected static class SkipSecondStepSearchGroupsContainer extends SearchGroupsContainer {
+
+    private final Map<Object, String> docIdToShard = new HashMap<>();
+
+    public SkipSecondStepSearchGroupsContainer(String[] fields) {
+      super(fields);
+    }
+
+    @Override
+    public void addSearchGroups(ShardResponse srsp, String field, Collection<SearchGroup<BytesRef>> searchGroups) {
+      super.addSearchGroups(srsp, field, searchGroups);
+      for (SearchGroup<BytesRef> searchGroup : searchGroups) {
+        assert(srsp.getShard() != null);
+        docIdToShard.put(searchGroup.topDocSolrId, srsp.getShard());
+      }
+    }
+
+    @Override
+    public void addMergedSearchGroups(ResponseBuilder rb, String groupField, Collection<SearchGroup<BytesRef>> mergedTopGroups ) {
+      // TODO: add comment or javadoc re: why this method is overridden as a no-op
+    }
+
+    @Override
+    public void addSearchGroupToShards(ResponseBuilder rb, String groupField, Collection<SearchGroup<BytesRef>> mergedTopGroups) {
+      super.addSearchGroupToShards(rb, groupField, mergedTopGroups);
+
+      final GroupingSpecification groupingSpecification = rb.getGroupingSpec();
+      final Sort groupSort = groupingSpecification.getGroupSort();
+      final String[] fields = groupingSpecification.getFields();
+
+      GroupDocs<BytesRef>[] groups = new GroupDocs[mergedTopGroups.size()];
+      Map<Object, ShardDoc> resultsId = new HashMap<>(mergedTopGroups.size());
+
+      // This is the max score found in any document on any group
+      float maxScore = 0;
+      int index = 0;
+
+      for (SearchGroup<BytesRef> group : mergedTopGroups) {
+        maxScore = Math.max(maxScore, group.topDocScore);
+        final String shard = docIdToShard.get(group.topDocSolrId);
+        assert(shard != null);
+        ShardDoc sdoc = new ShardDoc(group.topDocScore,
+            fields,
+            group.topDocSolrId,
+            shard );
+        sdoc.positionInResponse = index;
+
+        resultsId.put(sdoc.id, sdoc);
+        groups[index++] = new GroupDocs<BytesRef>(group.topDocScore,
+            group.topDocScore,
+            new TotalHits(1, TotalHits.Relation.EQUAL_TO), /* we don't know the actual number of hits in the group- we set it to 1 as we only keep track of the top doc */
+            new ShardDoc[] { sdoc }, /* only top doc */
+            group.groupValue,
+            group.sortValues);
+      }
+      TopGroups<BytesRef> topMergedGroups = new TopGroups<BytesRef>(groupSort.getSort(),
+          rb.getGroupingSpec().getSortWithinGroup().getSort(),
+          0, /*Set totalHitCount to 0 as we can't computed it as is */
+          0, /*Set totalGroupedHitCount to 0 as we can't computed it as is*/
+          groups,
+          maxScore);
+      rb.mergedTopGroups.put(groupField, topMergedGroups);
+
+      if(rb.resultIds == null) {
+        rb.resultIds = new HashMap<>();
+      }
+      rb.resultIds.putAll(resultsId);
+    }
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -52,10 +52,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
     this.searcher = searcher;
   }
 
-  public static SearchGroupsResultTransformer getInstance(SolrIndexSearcher searcher, boolean skipSecondStep){
-    return (skipSecondStep) ? new SkipSecondStepSearchResultResultTransformer(searcher) : new DefaultSearchResultResultTransformer(searcher);
-  }
-
   final protected Object[] getConvertedSortValues(final Object[] sortValues, final SortField[] sortFields) {
     Object[] convertedSortValues = new Object[sortValues.length];
     for (int i = 0; i < sortValues.length; i++) {
@@ -99,9 +95,9 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
 
   protected abstract NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command);
 
-  private static class DefaultSearchResultResultTransformer extends SearchGroupsResultTransformer {
+  public static class DefaultSearchResultResultTransformer extends SearchGroupsResultTransformer {
 
-    private DefaultSearchResultResultTransformer(SolrIndexSearcher searcher) {
+    public DefaultSearchResultResultTransformer(SolrIndexSearcher searcher) {
       super(searcher);
     }
 
@@ -163,13 +159,13 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
     }
   }
 
-  private static class SkipSecondStepSearchResultResultTransformer extends SearchGroupsResultTransformer {
+  public static class SkipSecondStepSearchResultResultTransformer extends SearchGroupsResultTransformer {
 
     private static final String TOP_DOC_SOLR_ID_KEY = "topDocSolrId";
     private static final String TOP_DOC_SCORE_KEY = "topDocScore";
     private static final String SORTVALUES_KEY  = "sortValues";
 
-    private SkipSecondStepSearchResultResultTransformer(SolrIndexSearcher searcher) {
+    public SkipSecondStepSearchResultResultTransformer(SolrIndexSearcher searcher) {
       super(searcher);
     }
 


### PR DESCRIPTION
1. replace the Map<String, Map<SearchGroup<BytesRef>, Set<String>>> tempSearchGroupToShards; local variable with a SearchGroupsContainer searchGroupsContainer; local variable and give the SearchGroupsContainer inner class methods that do what the code currently does i.e. just code refactoring
2. for the group.skip.second.step=true optimisation extend the SearchGroupsContainer class and override methods as required
3.  explore removal/replacement of the SearchGroupsResultTransformer.getInstance wrapper in order to avoid transforming SearchGroupsResultTransformer in an abstract class