### PR TITLE
Keep SearchGroupsResultTransformer concrete

### DIFF
--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
@@ -57,7 +57,7 @@ public class TestOpenNLPPOSFilterFactory extends BaseTokenStreamTestCase {
   }
 
   public void testBasic() throws IOException {
-    CustomAnalyzer analyzer = CustomAnalyzer.builder(new ClasspathResourceLoader(this.getClass()))
+    CustomAnalyzer analyzer = CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
         .withTokenizer("opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
         .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
         .build();

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
@@ -57,7 +57,7 @@ public class TestOpenNLPPOSFilterFactory extends BaseTokenStreamTestCase {
   }
 
   public void testBasic() throws IOException {
-    CustomAnalyzer analyzer = CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+    CustomAnalyzer analyzer = CustomAnalyzer.builder(new ClasspathResourceLoader(this.getClass()))
         .withTokenizer("opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
         .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
         .build();

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
@@ -139,9 +139,17 @@ public class FirstPassGroupingCollector<T> extends SimpleCollector {
       // System.out.println("  group=" + (group.groupValue == null ? "null" : group.groupValue.toString()));
       SearchGroup<T> searchGroup = new SearchGroup<>();
       searchGroup.groupValue = group.groupValue;
+      // We pass this around so that we can get the corresponding solr id when serializing the search group to send to the federator
+      searchGroup.topDocLuceneId = group.topDoc;
       searchGroup.sortValues = new Object[sortFieldCount];
       for(int sortFieldIDX=0;sortFieldIDX<sortFieldCount;sortFieldIDX++) {
         searchGroup.sortValues[sortFieldIDX] = comparators[sortFieldIDX].value(group.comparatorSlot);
+      }
+      // TODO: It should be possible to extend this to handle more than one FieldComparator and other types
+      if (sortFieldCount > 0 && comparators[0] instanceof FieldComparator.RelevanceComparator ){
+        searchGroup.topDocScore = (Float)comparators[0].value(group.comparatorSlot);
+      } else {
+        searchGroup.topDocScore = -1;
       }
       result.add(searchGroup);
     }

--- a/solr/contrib/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
+++ b/solr/contrib/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
@@ -73,7 +73,7 @@ import static org.apache.solr.common.SolrException.ErrorCode.SERVER_ERROR;
  *     &lt;/analyzer&gt;
  *   &lt;/fieldType&gt;
  * </pre>
- * 
+ *
  * <p>See the <a href="http://opennlp.apache.org/models.html">OpenNLP website</a>
  * for information on downloading pre-trained models.</p>
  *

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -1322,14 +1322,6 @@ public class QueryComponent extends SearchComponent
     return true;
   }
 
-  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(ResponseBuilder rb, SolrIndexSearcher searcher) {
-    if (rb.getGroupingSpec().isSkipSecondGroupingStep()) {
-      return new SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer(searcher);
-    } else {
-      return new SearchGroupsResultTransformer.DefaultSearchResultResultTransformer(searcher);
-    }
-  }
-
   private void doProcessGroupedDistributedSearchFirstPhase(ResponseBuilder rb, QueryCommand cmd, QueryResult result) throws IOException {
 
     GroupingSpecification groupingSpec = rb.getGroupingSpec();
@@ -1359,7 +1351,7 @@ public class QueryComponent extends SearchComponent
 
     CommandHandler commandHandler = topsGroupsActionBuilder.build();
     commandHandler.execute();
-    SearchGroupsResultTransformer serializer = newSearchGroupsResultTransformer(rb, searcher);
+    SearchGroupsResultTransformer serializer = new SearchGroupsResultTransformer(searcher, rb.getGroupingSpec().isSkipSecondGroupingStep());
 
     rsp.add("firstPhase", commandHandler.processResult(result, serializer));
     rsp.add("totalHitCount", commandHandler.getTotalHitCount());

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -235,32 +235,33 @@ public class QueryComponent extends SearchComponent
   private boolean allowSkipSecondGroupingStep(final GroupingSpecification groupingSpec, final boolean isReranking ) {
     // Only possible if we only want one doc per group
     if (groupingSpec.getGroupLimit() != 1) {
-        logger.error("group.skip.second.step=true is not compatible with group.limit == " + groupingSpec.getGroupLimit() );
+        LOG.error("group.skip.second.step=true is not compatible with group.limit == " + groupingSpec.getGroupLimit() );
         return false;
     }
 
     // Within group sort must be the same as group sort because if we skip second step no sorting within group will be done.
     if (groupingSpec.getSortWithinGroup() !=  groupingSpec.getGroupSort()) {
-        logger.error("group.skip.second.step=true is not compatible with group.sort != sort");
+        LOG.error("group.skip.second.step=true is not compatible with group.sort != sort");
         return false;
     }
 
     boolean byRelevanceOnly = false;
     SortField[] sortFields = groupingSpec.getGroupSort().getSort();
 
-    if(sortFields != null && sortFields.length == 1 && sortFields[0] != null && sortFields[0].getComparator() instanceof FieldComparator.RelevanceComparator) {
+    // TODO: uncomment-and-adjust the commented out if-clause below
+    if(sortFields != null && sortFields.length == 1 && sortFields[0] != null /* && sortFields[0].getComparator() instanceof FieldComparator.RelevanceComparator */) {
       byRelevanceOnly = true;
     }
 
     // TODO: At the moment the optimization is only supported when we are sorting by relevance only
     if(!byRelevanceOnly) {
-        logger.error("group.skip.second.step=true is not compatible with sort= " + (sortFields != null? sortFields.toString() : null));
+        LOG.error("group.skip.second.step=true is not compatible with sort= " + (sortFields != null? sortFields.toString() : null));
         return false;
     }
 
     // TODO: At the moment the optimization does not support reranking
     if(isReranking) {
-        logger.error("group.skip.second.step=true is not compatible with reranking");
+        LOG.error("group.skip.second.step=true is not compatible with reranking");
         return false;
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -235,13 +235,13 @@ public class QueryComponent extends SearchComponent
   private boolean allowSkipSecondGroupingStep(final GroupingSpecification groupingSpec, final boolean isReranking ) {
     // Only possible if we only want one doc per group
     if (groupingSpec.getGroupLimit() != 1) {
-        LOG.error("group.skip.second.step=true is not compatible with group.limit == " + groupingSpec.getGroupLimit() );
+        log.error("group.skip.second.step=true is not compatible with group.limit == " + groupingSpec.getGroupLimit() );
         return false;
     }
 
     // Within group sort must be the same as group sort because if we skip second step no sorting within group will be done.
     if (groupingSpec.getSortWithinGroup() !=  groupingSpec.getGroupSort()) {
-        LOG.error("group.skip.second.step=true is not compatible with group.sort != sort");
+        log.error("group.skip.second.step=true is not compatible with group.sort != sort");
         return false;
     }
 
@@ -255,13 +255,13 @@ public class QueryComponent extends SearchComponent
 
     // TODO: At the moment the optimization is only supported when we are sorting by relevance only
     if(!byRelevanceOnly) {
-        LOG.error("group.skip.second.step=true is not compatible with sort= " + (sortFields != null? sortFields.toString() : null));
+        log.error("group.skip.second.step=true is not compatible with sort= " + (sortFields != null? sortFields.toString() : null));
         return false;
     }
 
     // TODO: At the moment the optimization does not support reranking
     if(isReranking) {
-        LOG.error("group.skip.second.step=true is not compatible with reranking");
+        log.error("group.skip.second.step=true is not compatible with reranking");
         return false;
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -232,6 +232,41 @@ public class QueryComponent extends SearchComponent
     }
   }
 
+  private boolean allowSkipSecondGroupingStep(final GroupingSpecification groupingSpec, final boolean isReranking ) {
+    // Only possible if we only want one doc per group
+    if (groupingSpec.getGroupLimit() != 1) {
+        logger.error("group.skip.second.step=true is not compatible with group.limit == " + groupingSpec.getGroupLimit() );
+        return false;
+    }
+
+    // Within group sort must be the same as group sort because if we skip second step no sorting within group will be done.
+    if (groupingSpec.getSortWithinGroup() !=  groupingSpec.getGroupSort()) {
+        logger.error("group.skip.second.step=true is not compatible with group.sort != sort");
+        return false;
+    }
+
+    boolean byRelevanceOnly = false;
+    SortField[] sortFields = groupingSpec.getGroupSort().getSort();
+
+    if(sortFields != null && sortFields.length == 1 && sortFields[0] != null && sortFields[0].getComparator() instanceof FieldComparator.RelevanceComparator) {
+      byRelevanceOnly = true;
+    }
+
+    // TODO: At the moment the optimization is only supported when we are sorting by relevance only
+    if(!byRelevanceOnly) {
+        logger.error("group.skip.second.step=true is not compatible with sort= " + (sortFields != null? sortFields.toString() : null));
+        return false;
+    }
+
+    // TODO: At the moment the optimization does not support reranking
+    if(isReranking) {
+        logger.error("group.skip.second.step=true is not compatible with reranking");
+        return false;
+    }
+
+    return true;
+  }
+
   protected void prepareGrouping(ResponseBuilder rb) throws IOException {
 
     SolrQueryRequest req = rb.req;
@@ -288,6 +323,13 @@ public class QueryComponent extends SearchComponent
     groupingSpec.setMain(params.getBool(GroupParams.GROUP_MAIN, false));
     groupingSpec.setNeedScore((rb.getFieldFlags() & SolrIndexSearcher.GET_SCORES) != 0);
     groupingSpec.setTruncateGroups(params.getBool(GroupParams.GROUP_TRUNCATE, false));
+
+    groupingSpec.setSkipSecondGroupingStep(params.getBool(GroupParams.GROUP_SKIP_DISTRIBUTED_SECOND, false));
+    boolean isReranking = (rb.getRankQuery() != null);
+    if (groupingSpec.isSkipSecondGroupingStep() & !allowSkipSecondGroupingStep(groupingSpec, isReranking)){
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
+          "Illegal grouping specification for skip second step optimization: " + groupingSpec.toString());
+    }
   }
 
 
@@ -530,6 +572,12 @@ public class QueryComponent extends SearchComponent
     } else if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
       shardRequestFactory = new StoredFieldsShardRequestFactory();
       nextStage = ResponseBuilder.STAGE_DONE;
+    }
+
+    if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY && rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+      shardRequestFactory = new StoredFieldsShardRequestFactory();
+      nextStage = ResponseBuilder.STAGE_DONE;
+      rb.stage = ResponseBuilder.STAGE_GET_FIELDS;
     }
 
     if (shardRequestFactory != null) {
@@ -1294,7 +1342,7 @@ public class QueryComponent extends SearchComponent
 
     CommandHandler commandHandler = topsGroupsActionBuilder.build();
     commandHandler.execute();
-    SearchGroupsResultTransformer serializer = new SearchGroupsResultTransformer(searcher);
+    SearchGroupsResultTransformer serializer = SearchGroupsResultTransformer.getInstance(searcher, rb.getGroupingSpec().isSkipSecondGroupingStep());
 
     rsp.add("firstPhase", commandHandler.processResult(result, serializer));
     rsp.add("totalHitCount", commandHandler.getTotalHitCount());

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -569,19 +569,15 @@ public class QueryComponent extends SearchComponent
     } else if (rb.stage < ResponseBuilder.STAGE_EXECUTE_QUERY) {
       nextStage = ResponseBuilder.STAGE_EXECUTE_QUERY;
     } else if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY) {
-      shardRequestFactory = new TopGroupsShardRequestFactory();
+      if (!rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+        shardRequestFactory = new TopGroupsShardRequestFactory();
+      }
       nextStage = ResponseBuilder.STAGE_GET_FIELDS;
     } else if (rb.stage < ResponseBuilder.STAGE_GET_FIELDS) {
       nextStage = ResponseBuilder.STAGE_GET_FIELDS;
     } else if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
       shardRequestFactory = new StoredFieldsShardRequestFactory();
       nextStage = ResponseBuilder.STAGE_DONE;
-    }
-
-    if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY && rb.getGroupingSpec().isSkipSecondGroupingStep()) {
-      shardRequestFactory = new StoredFieldsShardRequestFactory();
-      nextStage = ResponseBuilder.STAGE_DONE;
-      rb.stage = ResponseBuilder.STAGE_GET_FIELDS;
     }
 
     if (shardRequestFactory != null) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -237,18 +237,19 @@ public class QueryComponent extends SearchComponent
     final int limit =  withinGroupSpecification.getCount();
     final int offset = withinGroupSpecification.getOffset();
     if ( limit != 1 || offset != 0 ) {
-        log.error("group.skip.second.step=true is not compatible with group.limit == " + limit);
+        log.error("group.skip.second.step=true is not compatible with group.limit (limit={}) ", limit);
         return false;
     }
 
     // Within group sort must be the same as group sort because if we skip second step no sorting within group will be done.
     if (withinGroupSpecification.getSort() !=  groupSort.getSort()) {
-        log.error("group.skip.second.step=true is not compatible with group.sort != sort");
+        log.error("group.skip.second.step=true is not compatible with group.sort ({}) != sort ({})",
+                  withinGroupSpecification.getSort(), groupSort.getSort());
         return false;
     }
 
     boolean byRelevanceOnly = false;
-    SortField[] sortFields = withinGroupSpecification.getSort().getSort();
+    final SortField[] sortFields = withinGroupSpecification.getSort().getSort();
 
     // TODO: uncomment-and-adjust the commented out if-clause below
     if(sortFields != null && sortFields.length == 1 && sortFields[0] != null /* && sortFields[0].getComparator() instanceof FieldComparator.RelevanceComparator */) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -98,6 +98,7 @@ import org.apache.solr.search.grouping.distributed.requestfactory.SearchGroupsRe
 import org.apache.solr.search.grouping.distributed.requestfactory.StoredFieldsShardRequestFactory;
 import org.apache.solr.search.grouping.distributed.requestfactory.TopGroupsShardRequestFactory;
 import org.apache.solr.search.grouping.distributed.responseprocessor.SearchGroupShardResponseProcessor;
+import org.apache.solr.search.grouping.distributed.responseprocessor.SkipSecondStepSearchGroupShardResponseProcessor;
 import org.apache.solr.search.grouping.distributed.responseprocessor.StoredFieldsShardResponseProcessor;
 import org.apache.solr.search.grouping.distributed.responseprocessor.TopGroupsShardResponseProcessor;
 import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer;
@@ -617,10 +618,18 @@ public class QueryComponent extends SearchComponent
     }
   }
 
+  protected SearchGroupShardResponseProcessor newSearchGroupShardResponseProcessor(ResponseBuilder rb) {
+    if (rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+      return new SkipSecondStepSearchGroupShardResponseProcessor();
+    } else {
+      return new SearchGroupShardResponseProcessor();
+    }
+  }
+
   protected void handleGroupedResponses(ResponseBuilder rb, ShardRequest sreq) {
     ShardResponseProcessor responseProcessor = null;
     if ((sreq.purpose & ShardRequest.PURPOSE_GET_TOP_GROUPS) != 0) {
-      responseProcessor = new SearchGroupShardResponseProcessor();
+      responseProcessor = newSearchGroupShardResponseProcessor(rb);
     } else if ((sreq.purpose & ShardRequest.PURPOSE_GET_TOP_IDS) != 0) {
       responseProcessor = new TopGroupsShardResponseProcessor();
     } else if ((sreq.purpose & ShardRequest.PURPOSE_GET_FIELDS) != 0) {
@@ -1313,6 +1322,14 @@ public class QueryComponent extends SearchComponent
     return true;
   }
 
+  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(ResponseBuilder rb, SolrIndexSearcher searcher) {
+    if (rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+      return new SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer(searcher);
+    } else {
+      return new SearchGroupsResultTransformer.DefaultSearchResultResultTransformer(searcher);
+    }
+  }
+
   private void doProcessGroupedDistributedSearchFirstPhase(ResponseBuilder rb, QueryCommand cmd, QueryResult result) throws IOException {
 
     GroupingSpecification groupingSpec = rb.getGroupingSpec();
@@ -1342,7 +1359,7 @@ public class QueryComponent extends SearchComponent
 
     CommandHandler commandHandler = topsGroupsActionBuilder.build();
     commandHandler.execute();
-    SearchGroupsResultTransformer serializer = SearchGroupsResultTransformer.getInstance(searcher, rb.getGroupingSpec().isSkipSecondGroupingStep());
+    SearchGroupsResultTransformer serializer = newSearchGroupsResultTransformer(rb, searcher);
 
     rsp.add("firstPhase", commandHandler.processResult(result, serializer));
     rsp.add("totalHitCount", commandHandler.getTotalHitCount());

--- a/solr/core/src/java/org/apache/solr/search/grouping/GroupingSpecification.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/GroupingSpecification.java
@@ -37,6 +37,12 @@ public class GroupingSpecification {
   private Grouping.Format responseFormat;
   private boolean needScore;
   private boolean truncateGroups;
+  /* This is an optimization to skip the second grouping step when groupLimit is 1. The second
+  * grouping step retrieves the top K documents for each group. This is not necessary when only one
+  * document per group is required because in the first step every shard sends back the group score given
+  * by its top document.
+  */
+  private boolean skipSecondGroupingStep;
 
   public String[] getFields() {
     return fields;
@@ -173,5 +179,9 @@ public class GroupingSpecification {
   public void setWithinGroupSortSpec(SortSpec withinGroupSortSpec) {
     this.withinGroupSortSpec = withinGroupSortSpec;
   }
+
+  public boolean isSkipSecondGroupingStep() { return skipSecondGroupingStep; }
+
+  public void setSkipSecondGroupingStep(boolean skipSecondGroupingStep) { this.skipSecondGroupingStep = skipSecondGroupingStep; }
 
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/GroupConverter.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/GroupConverter.java
@@ -52,6 +52,8 @@ class GroupConverter {
     for (SearchGroup<MutableValue> original : values) {
       SearchGroup<BytesRef> converted = new SearchGroup<BytesRef>();
       converted.sortValues = original.sortValues;
+      converted.topDocLuceneId = original.topDocLuceneId;
+      converted.topDocScore = original.topDocScore;
       if (original.groupValue.exists) {
         BytesRefBuilder binary = new BytesRefBuilder();
         fieldType.readableToIndexed(original.groupValue.toString(), binary);

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -55,16 +55,16 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
   @Override
   public void process(ResponseBuilder rb, ShardRequest shardRequest) {
     SortSpec groupSortSpec = rb.getGroupingSpec().getGroupSortSpec();
-    Sort groupSort = rb.getGroupingSpec().getGroupSort();
+    Sort groupSort = rb.getGroupingSpec().getGroupSortSpec().getSort();
     final String[] fields = rb.getGroupingSpec().getFields();
-    Sort withinGroupSort = rb.getGroupingSpec().getSortWithinGroup();
+    Sort withinGroupSort = rb.getGroupingSpec().getWithinGroupSortSpec().getSort();
     assert withinGroupSort != null;
 
     final Map<String, List<Collection<SearchGroup<BytesRef>>>> commandSearchGroups = new HashMap<>(fields.length, 1.0f);
     for (String field : fields) {
-      commandSearchGroups.put(field, new ArrayList<Collection<SearchGroup<BytesRef>>>(shardRequest.responses.size()));
+      commandSearchGroups.put(field, new ArrayList<>(shardRequest.responses.size()));
       if (!rb.searchGroupToShards.containsKey(field)) {
-        rb.searchGroupToShards.put(field, new HashMap<SearchGroup<BytesRef>, Set<String>>());
+        rb.searchGroupToShards.put(field, new HashMap<>());
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -48,10 +48,6 @@ import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchG
  */
 public class SearchGroupShardResponseProcessor implements ShardResponseProcessor {
 
-  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(SolrIndexSearcher solrIndexSearcher) {
-    return new SearchGroupsResultTransformer.DefaultSearchResultResultTransformer(solrIndexSearcher);
-  }
-
   protected SearchGroupsContainer newSearchGroupsContainer(ResponseBuilder rb) {
       return new SearchGroupsContainer(rb.getGroupingSpec().getFields());
   }
@@ -72,7 +68,7 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       }
     }
 
-    SearchGroupsResultTransformer serializer = newSearchGroupsResultTransformer(rb.req.getSearcher());
+    SearchGroupsResultTransformer serializer = new SearchGroupsResultTransformer(rb.req.getSearcher(), rb.getGroupingSpec().isSkipSecondGroupingStep());
     int maxElapsedTime = 0;
     int hitCountDuringFirstPhase = 0;
 

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.grouping.GroupDocs;
 import org.apache.lucene.search.grouping.SearchGroup;
 import org.apache.lucene.search.grouping.TopGroups;
@@ -187,7 +188,7 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       resultsId.put(sdoc.id, sdoc);
       groups[index++] = new GroupDocs<BytesRef>(group.topDocScore,
           group.topDocScore,
-          1, /* we don't know the actual number of hits in the group- we set it to 1 as we only keep track of the top doc */
+          new TotalHits(1, TotalHits.Relation.EQUAL_TO), /* we don't know the actual number of hits in the group- we set it to 1 as we only keep track of the top doc */
           new ShardDoc[] { sdoc }, /* only top doc */
           group.groupValue,
           group.sortValues);

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -27,13 +27,16 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.grouping.GroupDocs;
 import org.apache.lucene.search.grouping.SearchGroup;
+import org.apache.lucene.search.grouping.TopGroups;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardDoc;
 import org.apache.solr.handler.component.ShardRequest;
 import org.apache.solr.handler.component.ShardResponse;
 import org.apache.solr.response.SolrQueryResponse;
@@ -65,7 +68,9 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       }
     }
 
-    SearchGroupsResultTransformer serializer = new SearchGroupsResultTransformer(rb.req.getSearcher());
+    final SearchGroupsResultTransformer serializer = SearchGroupsResultTransformer.getInstance(rb.req.getSearcher(), rb.getGroupingSpec().isSkipSecondGroupingStep());
+    final Map<Object, String> docIdToShard = new HashMap<>();
+
     int maxElapsedTime = 0;
     int hitCountDuringFirstPhase = 0;
 
@@ -130,6 +135,8 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
             shards = new HashSet<>();
             map.put(searchGroup, shards);
           }
+          assert(srsp.getShard() != null);
+          docIdToShard.put(searchGroup.topDocSolrId, srsp.getShard());
           shards.add(srsp.getShard());
         }
       }
@@ -143,12 +150,61 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       if (mergedTopGroups == null) {
         continue;
       }
-
-      rb.mergedSearchGroups.put(groupField, mergedTopGroups);
-      for (SearchGroup<BytesRef> mergedTopGroup : mergedTopGroups) {
-        rb.searchGroupToShards.get(groupField).put(mergedTopGroup, tempSearchGroupToShards.get(groupField).get(mergedTopGroup));
+      if (rb.getGroupingSpec().isSkipSecondGroupingStep()){
+          /* If we are skipping the second grouping step we want to translate the response of the
+           * first step in the response of the second step and send it to the get_fields step.
+           */
+          processSkipSecondGroupingStep(rb, mergedTopGroups, tempSearchGroupToShards, docIdToShard, groupSort, fields,  groupField);
+      }
+      else {
+        rb.mergedSearchGroups.put(groupField, mergedTopGroups);
+        for (SearchGroup<BytesRef> mergedTopGroup : mergedTopGroups) {
+          rb.searchGroupToShards.get(groupField).put(mergedTopGroup, tempSearchGroupToShards.get(groupField).get(mergedTopGroup));
+        }
       }
     }
+  }
+
+  private void processSkipSecondGroupingStep(final ResponseBuilder rb, final Collection<SearchGroup<BytesRef>> mergedTopGroups, final Map<String, Map<SearchGroup<BytesRef>, Set<String>>> tempSearchGroupToShards, Map<Object, String> docIdToShard, Sort groupSort, final String[] fields, final String groupField){
+    GroupDocs<BytesRef>[] groups = new GroupDocs[mergedTopGroups.size()];
+    Map<Object, ShardDoc> resultsId = new HashMap<>(mergedTopGroups.size());
+
+    // This is the max score found in any document on any group
+    float maxScore = 0;
+    int index = 0;
+
+    for (SearchGroup<BytesRef> group : mergedTopGroups) {
+      maxScore = Math.max(maxScore, group.topDocScore);
+      rb.searchGroupToShards.get(groupField).put(group, tempSearchGroupToShards.get(groupField).get(group));
+      final String shard = docIdToShard.get(group.topDocSolrId);
+      assert(shard != null);
+      ShardDoc sdoc = new ShardDoc(group.topDocScore,
+          fields,
+          group.topDocSolrId,
+          shard );
+      sdoc.positionInResponse = index;
+
+      resultsId.put(sdoc.id, sdoc);
+      groups[index++] = new GroupDocs<BytesRef>(group.topDocScore,
+          group.topDocScore,
+          1, /* we don't know the actual number of hits in the group- we set it to 1 as we only keep track of the top doc */
+          new ShardDoc[] { sdoc }, /* only top doc */
+          group.groupValue,
+          group.sortValues);
+    }
+    TopGroups<BytesRef> topMergedGroups = new TopGroups<BytesRef>(groupSort.getSort(),
+        rb.getGroupingSpec().getSortWithinGroup().getSort(),
+        0, /*Set totalHitCount to 0 as we can't computed it as is */
+        0, /*Set totalGroupedHitCount to 0 as we can't computed it as is*/
+        groups,
+        maxScore);
+    rb.mergedTopGroups.put(groupField, topMergedGroups);
+
+    if(rb.resultIds == null) {
+      rb.resultIds = new HashMap<>();
+    }
+
+    rb.resultIds.putAll(resultsId);
   }
 
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
@@ -29,16 +29,9 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.ShardDoc;
 import org.apache.solr.handler.component.ShardResponse;
-import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.grouping.GroupingSpecification;
-import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer;
 
 public class SkipSecondStepSearchGroupShardResponseProcessor extends SearchGroupShardResponseProcessor {
-
-  @Override
-  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(SolrIndexSearcher solrIndexSearcher) {
-    return new SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer(solrIndexSearcher);
-  }
 
   @Override
   protected SearchGroupsContainer newSearchGroupsContainer(ResponseBuilder rb) {

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
@@ -32,7 +32,6 @@ import org.apache.solr.handler.component.ShardResponse;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.grouping.GroupingSpecification;
 import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer;
-import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer;
 
 public class SkipSecondStepSearchGroupShardResponseProcessor extends SearchGroupShardResponseProcessor {
 

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SkipSecondStepSearchGroupShardResponseProcessor.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.grouping.distributed.responseprocessor;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.grouping.GroupDocs;
+import org.apache.lucene.search.grouping.SearchGroup;
+import org.apache.lucene.search.grouping.TopGroups;
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardDoc;
+import org.apache.solr.handler.component.ShardResponse;
+import org.apache.solr.search.SolrIndexSearcher;
+import org.apache.solr.search.grouping.GroupingSpecification;
+import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer;
+import org.apache.solr.search.grouping.distributed.shardresultserializer.SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer;
+
+public class SkipSecondStepSearchGroupShardResponseProcessor extends SearchGroupShardResponseProcessor {
+
+  @Override
+  protected SearchGroupsResultTransformer newSearchGroupsResultTransformer(SolrIndexSearcher solrIndexSearcher) {
+    return new SearchGroupsResultTransformer.SkipSecondStepSearchResultResultTransformer(solrIndexSearcher);
+  }
+
+  @Override
+  protected SearchGroupsContainer newSearchGroupsContainer(ResponseBuilder rb) {
+    return new SkipSecondStepSearchGroupsContainer(rb.getGroupingSpec().getFields());
+  }
+
+  protected static class SkipSecondStepSearchGroupsContainer extends SearchGroupsContainer {
+
+    private final Map<Object, String> docIdToShard = new HashMap<>();
+
+    public SkipSecondStepSearchGroupsContainer(String[] fields) {
+      super(fields);
+    }
+
+    @Override
+    public void addSearchGroups(ShardResponse srsp, String field, Collection<SearchGroup<BytesRef>> searchGroups) {
+      super.addSearchGroups(srsp, field, searchGroups);
+      for (SearchGroup<BytesRef> searchGroup : searchGroups) {
+        assert(srsp.getShard() != null);
+        docIdToShard.put(searchGroup.topDocSolrId, srsp.getShard());
+      }
+    }
+
+    @Override
+    public void addMergedSearchGroups(ResponseBuilder rb, String groupField, Collection<SearchGroup<BytesRef>> mergedTopGroups ) {
+      // TODO: add comment or javadoc re: why this method is overridden as a no-op
+    }
+
+    @Override
+    public void addSearchGroupToShards(ResponseBuilder rb, String groupField, Collection<SearchGroup<BytesRef>> mergedTopGroups) {
+      super.addSearchGroupToShards(rb, groupField, mergedTopGroups);
+
+      final GroupingSpecification groupingSpecification = rb.getGroupingSpec();
+      final Sort groupSort = groupingSpecification.getGroupSort();
+      final String[] fields = groupingSpecification.getFields();
+
+      GroupDocs<BytesRef>[] groups = new GroupDocs[mergedTopGroups.size()];
+      Map<Object, ShardDoc> resultsId = new HashMap<>(mergedTopGroups.size());
+
+      // This is the max score found in any document on any group
+      float maxScore = 0;
+      int index = 0;
+
+      for (SearchGroup<BytesRef> group : mergedTopGroups) {
+        maxScore = Math.max(maxScore, group.topDocScore);
+        final String shard = docIdToShard.get(group.topDocSolrId);
+        assert(shard != null);
+        ShardDoc sdoc = new ShardDoc(group.topDocScore,
+            fields,
+            group.topDocSolrId,
+            shard );
+        sdoc.positionInResponse = index;
+
+        resultsId.put(sdoc.id, sdoc);
+        groups[index++] = new GroupDocs<BytesRef>(group.topDocScore,
+            group.topDocScore,
+            new TotalHits(1, TotalHits.Relation.EQUAL_TO), /* we don't know the actual number of hits in the group- we set it to 1 as we only keep track of the top doc */
+            new ShardDoc[] { sdoc }, /* only top doc */
+            group.groupValue,
+            group.sortValues);
+      }
+      TopGroups<BytesRef> topMergedGroups = new TopGroups<BytesRef>(groupSort.getSort(),
+          rb.getGroupingSpec().getSortWithinGroup().getSort(),
+          0, /*Set totalHitCount to 0 as we can't computed it as is */
+          0, /*Set totalGroupedHitCount to 0 as we can't computed it as is*/
+          groups,
+          maxScore);
+      rb.mergedTopGroups.put(groupField, topMergedGroups);
+
+      if(rb.resultIds == null) {
+        rb.resultIds = new HashMap<>();
+      }
+      rb.resultIds.putAll(resultsId);
+    }
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -47,7 +47,7 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
   private static final String GROUP_COUNT = "groupCount";
 
   protected final SolrIndexSearcher searcher;
-  private final SearchGroupsFieldCommandTransformer searchGroupsTransformer;
+  private final SearchGroupsFieldCommandSerializer searchGroupsTransformer;
 
   public SearchGroupsResultTransformer(SolrIndexSearcher searcher) {
     this(searcher, false);
@@ -56,9 +56,9 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
   public SearchGroupsResultTransformer(SolrIndexSearcher searcher, boolean skipSecondStep) {
     this.searcher = searcher;
     if (skipSecondStep){
-      searchGroupsTransformer = new SkipSecondStepSearchGroupsFieldCommandTransformer();
+      searchGroupsTransformer = new SkipSecondStepSearchGroupsFieldCommandSerializer();
     } else {
-      searchGroupsTransformer = new DefaultSearchGroupsFieldCommandTransformer();
+      searchGroupsTransformer = new DefaultSearchGroupsFieldCommandSerializer();
     }
   }
 
@@ -143,13 +143,13 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
     return searchGroup;
   }
 
-  private interface SearchGroupsFieldCommandTransformer {
+  private interface SearchGroupsFieldCommandSerializer {
       Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard);
       NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command);
 
     }
 
-    class DefaultSearchGroupsFieldCommandTransformer implements SearchGroupsFieldCommandTransformer {
+    class DefaultSearchGroupsFieldCommandSerializer implements SearchGroupsFieldCommandSerializer {
 
     public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
       final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
@@ -202,7 +202,7 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
     }
   }
 
-  public class SkipSecondStepSearchGroupsFieldCommandTransformer implements SearchGroupsFieldCommandTransformer {
+  public class SkipSecondStepSearchGroupsFieldCommandSerializer implements SearchGroupsFieldCommandSerializer {
 
     private static final String TOP_DOC_SOLR_ID_KEY = "topDocSolrId";
     private static final String TOP_DOC_SCORE_KEY = "topDocScore";

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -16,12 +16,19 @@
  */
 package org.apache.solr.search.grouping.distributed.shardresultserializer;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DocumentStoredFieldVisitor;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.grouping.SearchGroup;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.grouping.Command;
@@ -34,17 +41,41 @@ import java.util.*;
 /**
  * Implementation for transforming {@link SearchGroup} into a {@link NamedList} structure and visa versa.
  */
-public class SearchGroupsResultTransformer implements ShardResultTransformer<List<Command>, Map<String, SearchGroupsFieldCommandResult>> {
+public abstract class SearchGroupsResultTransformer implements ShardResultTransformer<List<Command>, Map<String, SearchGroupsFieldCommandResult>> {
 
   private static final String TOP_GROUPS = "topGroups";
   private static final String GROUP_COUNT = "groupCount";
 
-  private final SolrIndexSearcher searcher;
+  protected final SolrIndexSearcher searcher;
 
-  public SearchGroupsResultTransformer(SolrIndexSearcher searcher) {
+  private SearchGroupsResultTransformer(SolrIndexSearcher searcher) {
     this.searcher = searcher;
   }
 
+  public static SearchGroupsResultTransformer getInstance(SolrIndexSearcher searcher, boolean skipSecondStep){
+    return (skipSecondStep) ? new SkipSecondStepSearchResultResultTransformer(searcher) : new DefaultSearchResultResultTransformer(searcher);
+  }
+
+  final protected Object[] getConvertedSortValues(final Object[] sortValues, final SortField[] sortFields) {
+    Object[] convertedSortValues = new Object[sortValues.length];
+    for (int i = 0; i < sortValues.length; i++) {
+      Object sortValue = sortValues[i];
+      SchemaField field = sortFields[i].getField() != null ? searcher.getSchema().getFieldOrNull(sortFields[i].getField()) : null;
+      if (field != null) {
+        FieldType fieldType = field.getType();
+        if (sortValue != null) {
+          sortValue = fieldType.marshalSortValue(sortValue);
+        }
+      }
+      convertedSortValues[i] = sortValue;
+    }
+    return convertedSortValues;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+>>>>>>> SOLR-11831: Skip second grouping step if group.limit is 1 (aka Las Vegas patch)
   @Override
   public NamedList transform(List<Command> data) throws IOException {
     final NamedList<NamedList> result = new NamedList<>(data.size());
@@ -70,6 +101,7 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
     return result;
   }
 
+<<<<<<< HEAD
   @Override
   public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
     final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
@@ -90,40 +122,180 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
               searchGroup.groupValue = builder.get();
             } else {
               searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
+=======
+  protected abstract NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command);
+
+  private static class DefaultSearchResultResultTransformer extends SearchGroupsResultTransformer {
+
+    private DefaultSearchResultResultTransformer(SolrIndexSearcher searcher) {
+      super(searcher);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
+      final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
+      for (Map.Entry<String, NamedList> command : shardResponse) {
+        List<SearchGroup<BytesRef>> searchGroups = new ArrayList<>();
+        NamedList topGroupsAndGroupCount = command.getValue();
+        @SuppressWarnings("unchecked")
+        final NamedList<List<Comparable>> rawSearchGroups = (NamedList<List<Comparable>>) topGroupsAndGroupCount.get(TOP_GROUPS);
+        if (rawSearchGroups != null) {
+          for (Map.Entry<String, List<Comparable>> rawSearchGroup : rawSearchGroups){
+            SearchGroup<BytesRef> searchGroup = new SearchGroup<>();
+            SchemaField groupField = rawSearchGroup.getKey() != null? searcher.getSchema().getFieldOrNull(command.getKey()) : null;
+            searchGroup.groupValue = null;
+            if (rawSearchGroup.getKey() != null) {
+              if (groupField != null) {
+                BytesRefBuilder builder = new BytesRefBuilder();
+                groupField.getType().readableToIndexed(rawSearchGroup.getKey(), builder);
+                searchGroup.groupValue = builder.get();
+              } else {
+                searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
+              }
+>>>>>>> SOLR-11831: Skip second grouping step if group.limit is 1 (aka Las Vegas patch)
             }
+            searchGroup.sortValues = rawSearchGroup.getValue().toArray(new Comparable[rawSearchGroup.getValue().size()]);
+            for (int i = 0; i < searchGroup.sortValues.length; i++) {
+              SchemaField field = groupSort.getSort()[i].getField() != null ? searcher.getSchema().getFieldOrNull(groupSort.getSort()[i].getField()) : null;
+              searchGroup.sortValues[i] = ShardResultTransformerUtils.unmarshalSortValue(searchGroup.sortValues[i], field);
+            }
+            searchGroups.add(searchGroup);
           }
-          searchGroup.sortValues = rawSearchGroup.getValue().toArray(new Comparable[rawSearchGroup.getValue().size()]);
-          for (int i = 0; i < searchGroup.sortValues.length; i++) {
-            SchemaField field = groupSort.getSort()[i].getField() != null ? searcher.getSchema().getFieldOrNull(groupSort.getSort()[i].getField()) : null;
-            searchGroup.sortValues[i] = ShardResultTransformerUtils.unmarshalSortValue(searchGroup.sortValues[i], field);
-          }
-          searchGroups.add(searchGroup);
         }
+
+        final Integer groupCount = (Integer) topGroupsAndGroupCount.get(GROUP_COUNT);
+        result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
       }
-
-      final Integer groupCount = (Integer) topGroupsAndGroupCount.get(GROUP_COUNT);
-      result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
-    }
-    return result;
-  }
-
-  private NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command) {
-    final NamedList<Object[]> result = new NamedList<>(data.size());
-
-    for (SearchGroup<BytesRef> searchGroup : data) {
-      Object[] convertedSortValues = new Object[searchGroup.sortValues.length];
-      for (int i = 0; i < searchGroup.sortValues.length; i++) {
-        Object sortValue = searchGroup.sortValues[i];
-        SchemaField field = command.getGroupSort().getSort()[i].getField() != null ?
-            searcher.getSchema().getFieldOrNull(command.getGroupSort().getSort()[i].getField()) : null;
-        convertedSortValues[i] = ShardResultTransformerUtils.marshalSortValue(sortValue, field);
-      }
-      SchemaField field = searcher.getSchema().getFieldOrNull(command.getKey());
-      String groupValue = searchGroup.groupValue != null ? field.getType().indexedToReadable(searchGroup.groupValue, new CharsRefBuilder()).toString() : null;
-      result.add(groupValue, convertedSortValues);
+      return result;
     }
 
-    return result;
+    @Override
+    protected NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command) {
+      final NamedList<Object[]> result = new NamedList<>(data.size());
+
+      for (SearchGroup<BytesRef> searchGroup : data) {
+        Object[] convertedSortValues = new Object[searchGroup.sortValues.length];
+        for (int i = 0; i < searchGroup.sortValues.length; i++) {
+          Object sortValue = searchGroup.sortValues[i];
+          SchemaField field = command.getGroupSort().getSort()[i].getField() != null ?
+              searcher.getSchema().getFieldOrNull(command.getGroupSort().getSort()[i].getField()) : null;
+          convertedSortValues[i] = ShardResultTransformerUtils.marshalSortValue(sortValue, field);
+        }
+        SchemaField field = searcher.getSchema().getFieldOrNull(command.getKey());
+        String groupValue = searchGroup.groupValue != null ? field.getType().indexedToReadable(searchGroup.groupValue, new CharsRefBuilder()).toString() : null;
+        result.add(groupValue, convertedSortValues);
+      }
+
+      return result;
+    }
   }
 
+  private static class SkipSecondStepSearchResultResultTransformer extends SearchGroupsResultTransformer {
+
+    private static final String TOP_DOC_SOLR_ID_KEY = "topDocSolrId";
+    private static final String TOP_DOC_SCORE_KEY = "topDocScore";
+    private static final String SORTVALUES_KEY  = "sortValues";
+
+    private SkipSecondStepSearchResultResultTransformer(SolrIndexSearcher searcher) {
+      super(searcher);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
+      final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
+      for (Map.Entry<String, NamedList> command : shardResponse) {
+        List<SearchGroup<BytesRef>> searchGroups = new ArrayList<>();
+        NamedList topGroupsAndGroupCount = command.getValue();
+        @SuppressWarnings("unchecked")
+        final NamedList<List<Comparable>> rawSearchGroups = (NamedList<List<Comparable>>) topGroupsAndGroupCount.get(TOP_GROUPS);
+        if (rawSearchGroups != null) {
+          for (Map.Entry<String, List<Comparable>> rawSearchGroup : rawSearchGroups){
+            SearchGroup<BytesRef> searchGroup = new SearchGroup<>();
+            SchemaField groupField = rawSearchGroup.getKey() != null? searcher.getSchema().getFieldOrNull(command.getKey()) :    null;
+            searchGroup.groupValue = null;
+            if (rawSearchGroup.getKey() != null) {
+              if (groupField != null) {
+                BytesRefBuilder builder = new BytesRefBuilder();
+                groupField.getType().readableToIndexed(rawSearchGroup.getKey(), builder);
+                searchGroup.groupValue = builder.get();
+              } else {
+                searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
+              }
+            }
+            // I don't think we need this for upstream
+            //
+            // If we don't recognize this serialization throw an exception
+            // if (!isSerializationCompatible(rawSearchGroups)) {
+            //   logger.warn("Incompatible serialization/deserialization. Falling back to the default method");
+            //   throw new UnsupportedOperationException("Incompatible serialization/deserialization. Falling back to the default method");
+            // }
+            NamedList<Object> groupInfo = (NamedList) rawSearchGroup.getValue();
+            searchGroup.topDocLuceneId = DocIdSetIterator.NO_MORE_DOCS;
+            searchGroup.topDocScore = (float) groupInfo.get(TOP_DOC_SCORE_KEY);
+            searchGroup.topDocSolrId = groupInfo.get(TOP_DOC_SOLR_ID_KEY);
+            final ArrayList<?> sortValues = (ArrayList<?>)groupInfo.get(SORTVALUES_KEY);
+            searchGroup.sortValues = sortValues.toArray(new Comparable[sortValues.size()]);
+
+            final IndexSchema schema = searcher.getSchema();
+            for (int i = 0; i < searchGroup.sortValues.length; i++) {
+              final String sortField = groupSort.getSort()[i].getField();
+              final SchemaField field = (sortField != null) ? schema.getFieldOrNull(sortField) : null;
+              searchGroup.sortValues[i] = ShardResultTransformerUtils.unmarshalSortValue(searchGroup.sortValues[i], field);
+            }
+            searchGroups.add(searchGroup);
+          }
+        }
+
+        final Integer groupCount = (Integer) topGroupsAndGroupCount.get(GROUP_COUNT);
+        result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
+      }
+      return result;
+    }
+
+    @Override
+    protected NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command) {
+      final NamedList<NamedList> result = new NamedList<>(data.size());
+      for (SearchGroup<BytesRef> searchGroup : data) {
+
+        final IndexSchema schema = searcher.getSchema();
+        SchemaField uniqueField = schema.getUniqueKeyField();
+
+        Document luceneDoc = null;
+        /** Use the lucene id to get the unique solr id so that it can be sent to the federator.
+         * The lucene id of a document is not unique across all shards i.e. different documents
+         * in different shards could have the same lucene id, whereas the solr id is guaranteed
+         * to be unique so this is what we need to return to the federator
+        **/
+        try {
+          luceneDoc = retrieveDocument(uniqueField, searchGroup.topDocLuceneId);
+        } catch (IOException e) {
+          throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Cannot retrieve document for unique field " + uniqueField + " ("+e.toString()+")");
+        }
+        Object topDocSolrId = uniqueField.getType().toExternal(luceneDoc.getField(uniqueField.getName()));
+        NamedList<Object> groupInfo = new NamedList<>(5);
+        groupInfo.add(TOP_DOC_SCORE_KEY, searchGroup.topDocScore);
+        groupInfo.add(TOP_DOC_SOLR_ID_KEY, topDocSolrId);
+
+        Object[] convertedSortValues = getConvertedSortValues(searchGroup.sortValues, command.getGroupSort().getSort());
+        groupInfo.add(SORTVALUES_KEY, convertedSortValues);
+
+        SchemaField field = searcher.getSchema().getFieldOrNull(command.getKey());
+        final String groupValue = searchGroup.groupValue != null ? field.getType().indexedToReadable(searchGroup.groupValue, new CharsRefBuilder()).toString() : null;
+        result.add(groupValue, groupInfo);
+      }
+      return result;
+    }
+
+    private Document retrieveDocument(final SchemaField uniqueField, int doc) throws IOException {
+      DocumentStoredFieldVisitor visitor = new DocumentStoredFieldVisitor(uniqueField.getName());
+      searcher.doc(doc, visitor);
+      return visitor.getDocument();
+    }
+  }
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -179,9 +179,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
       super(searcher);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
       final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -52,10 +52,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
     this.searcher = searcher;
   }
 
-  public static SearchGroupsResultTransformer getInstance(SolrIndexSearcher searcher, boolean skipSecondStep){
-    return (skipSecondStep) ? new SkipSecondStepSearchResultResultTransformer(searcher) : new DefaultSearchResultResultTransformer(searcher);
-  }
-
   final protected Object[] getConvertedSortValues(final Object[] sortValues, final SortField[] sortFields) {
     Object[] convertedSortValues = new Object[sortValues.length];
     for (int i = 0; i < sortValues.length; i++) {
@@ -99,9 +95,9 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
 
   protected abstract NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command);
 
-  private static class DefaultSearchResultResultTransformer extends SearchGroupsResultTransformer {
+  public static class DefaultSearchResultResultTransformer extends SearchGroupsResultTransformer {
 
-    private DefaultSearchResultResultTransformer(SolrIndexSearcher searcher) {
+    public DefaultSearchResultResultTransformer(SolrIndexSearcher searcher) {
       super(searcher);
     }
 
@@ -163,13 +159,13 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
     }
   }
 
-  private static class SkipSecondStepSearchResultResultTransformer extends SearchGroupsResultTransformer {
+  public static class SkipSecondStepSearchResultResultTransformer extends SearchGroupsResultTransformer {
 
     private static final String TOP_DOC_SOLR_ID_KEY = "topDocSolrId";
     private static final String TOP_DOC_SCORE_KEY = "topDocScore";
     private static final String SORTVALUES_KEY  = "sortValues";
 
-    private SkipSecondStepSearchResultResultTransformer(SolrIndexSearcher searcher) {
+    public SkipSecondStepSearchResultResultTransformer(SolrIndexSearcher searcher) {
       super(searcher);
     }
 

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -72,9 +72,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
     return convertedSortValues;
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public NamedList transform(List<Command> data) throws IOException {
     final NamedList<NamedList> result = new NamedList<>(data.size());
@@ -108,9 +105,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
       super(searcher);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
       final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -75,7 +75,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
   /**
    * {@inheritDoc}
    */
->>>>>>> SOLR-11831: Skip second grouping step if group.limit is 1 (aka Las Vegas patch)
   @Override
   public NamedList transform(List<Command> data) throws IOException {
     final NamedList<NamedList> result = new NamedList<>(data.size());
@@ -101,28 +100,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
     return result;
   }
 
-<<<<<<< HEAD
-  @Override
-  public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
-    final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
-    for (Map.Entry<String, NamedList> command : shardResponse) {
-      List<SearchGroup<BytesRef>> searchGroups = new ArrayList<>();
-      NamedList topGroupsAndGroupCount = command.getValue();
-      @SuppressWarnings("unchecked")
-      final NamedList<List<Comparable>> rawSearchGroups = (NamedList<List<Comparable>>) topGroupsAndGroupCount.get(TOP_GROUPS);
-      if (rawSearchGroups != null) {
-        for (Map.Entry<String, List<Comparable>> rawSearchGroup : rawSearchGroups){
-          SearchGroup<BytesRef> searchGroup = new SearchGroup<>();
-          SchemaField groupField = rawSearchGroup.getKey() != null? searcher.getSchema().getFieldOrNull(command.getKey()) : null;
-          searchGroup.groupValue = null;
-          if (rawSearchGroup.getKey() != null) {
-            if (groupField != null) {
-              BytesRefBuilder builder = new BytesRefBuilder();
-              groupField.getType().readableToIndexed(rawSearchGroup.getKey(), builder);
-              searchGroup.groupValue = builder.get();
-            } else {
-              searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
-=======
   protected abstract NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command);
 
   private static class DefaultSearchResultResultTransformer extends SearchGroupsResultTransformer {
@@ -155,7 +132,6 @@ public abstract class SearchGroupsResultTransformer implements ShardResultTransf
               } else {
                 searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
               }
->>>>>>> SOLR-11831: Skip second grouping step if group.limit is 1 (aka Las Vegas patch)
             }
             searchGroup.sortValues = rawSearchGroup.getValue().toArray(new Comparable[rawSearchGroup.getValue().size()]);
             for (int i = 0; i < searchGroup.sortValues.length; i++) {

--- a/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/GroupedEndResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/GroupedEndResultTransformer.java
@@ -67,8 +67,14 @@ public class GroupedEndResultTransformer implements EndResultTransformer {
         for (GroupDocs<BytesRef> group : topGroups.groups) {
           SimpleOrderedMap<Object> groupResult = new SimpleOrderedMap<>();
           if (group.groupValue != null) {
+            final String groupValue;
+            if (rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+              groupValue = groupField.getType().indexedToReadable(group.groupValue.utf8ToString());
+            } else {
+              groupValue = group.groupValue.utf8ToString();
+            }
             groupResult.add(
-                "groupValue", groupFieldType.toObject(groupField.createField(group.groupValue.utf8ToString()))
+                "groupValue", groupFieldType.toObject(groupField.createField(groupValue))
             );
           } else {
             groupResult.add("groupValue", null);

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -310,6 +310,32 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
     
     //Debug
     simpleQuery("q", "*:*", "rows", 10, "fl", "id," + i1, "group", "true", "group.field", i1, "debug", "true");
+
+    // Ignore numFound if group.skip.second.step is enabled because the number of documents per group will not be computed (will default to 1)
+    handle.put("numFound", SKIP);
+    query("q", "{!func}id_i1", "rows", 3, "group.skip.second.step", true, "group.limit", 1,  "fl",  "id," + i1, "group", "true",
+               "group.field", i1);
+    query("q", "kings", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1);
+    query("q", "{!func}id_i1", "rows", 3, "group.skip.second.step", true,  "fl",  "id," + i1, "group", "true",
+          "group.field", i1);
+    query("q", "1234doesnotmatchanything1234", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1);
+
+    ignoreException("Illegal grouping specification");
+    assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.ngroups", true);
+    assertSimpleQueryThrows("q", "{!func}id", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 5);
+    assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 0);
+    handle.remove("numFound");
+
+  }
+
+  private void assertSimpleQueryThrows(Object... queryParams) {
+    boolean requestFailed = false;
+    try {
+      simpleQuery(queryParams);
+    } catch (Exception e) {
+      requestFailed = true;
+    }
+    assertTrue(requestFailed);
   }
 
   private void simpleQuery(Object... queryParams) throws SolrServerException, IOException {

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -310,22 +310,33 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
     
     //Debug
     simpleQuery("q", "*:*", "rows", 10, "fl", "id," + i1, "group", "true", "group.field", i1, "debug", "true");
+    testGroupSkipSecondStep();
+  }
 
+  /*
+    SOLR-11831, test skipping the second grouping step if the query only retrieves on document per group
+   */
+  private void testGroupSkipSecondStep() throws Exception {
     // Ignore numFound if group.skip.second.step is enabled because the number of documents per group will not be computed (will default to 1)
     handle.put("numFound", SKIP);
     query("q", "{!func}id_i1", "rows", 3, "group.skip.second.step", true, "group.limit", 1,  "fl",  "id," + i1, "group", "true",
-               "group.field", i1);
+        "group.field", i1);
     query("q", "kings", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1);
     query("q", "{!func}id_i1", "rows", 3, "group.skip.second.step", true,  "fl",  "id," + i1, "group", "true",
-          "group.field", i1);
+        "group.field", i1);
     query("q", "1234doesnotmatchanything1234", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1);
 
     ignoreException("Illegal grouping specification");
-    assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.ngroups", true);
+    // ngroups will return the corrent results, the problem is that numFound for each group might be wrong in case of multishard setting - but there is no way to
+    // enable/disable it.
+    //assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.ngroups", true);
     assertSimpleQueryThrows("q", "{!func}id", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 5);
     assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 0);
-    handle.remove("numFound");
+    // group sorted in a different way should fail
+    assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 0, "sort", i1+" desc");
+    assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 0, "group.sort", i1+" desc");
 
+    handle.remove("numFound");
   }
 
   private void assertSimpleQueryThrows(Object... queryParams) {

--- a/solr/solrj/src/java/org/apache/solr/common/params/GroupParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/GroupParams.java
@@ -66,5 +66,10 @@ public interface GroupParams {
   public static final String GROUP_DISTRIBUTED_SECOND = GROUP + ".distributed.second";
 
   public static final String GROUP_DISTRIBUTED_TOPGROUPS_PREFIX = GROUP + ".topgroups.";
+
+  /** activates optimization in case only one document per group.
+   * Setting this to true is only compatible with group.limit = 1
+   */
+  public static final String GROUP_SKIP_DISTRIBUTED_SECOND = GROUP + ".skip.second.step";
 }
 

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -860,9 +860,13 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
         }
       }
     }
-
-    cmp = compare(a.getNumFound(), b.getNumFound(), 0, handle);
-    if (cmp != null) return ".numFound" + cmp;
+    final int checkNumFound = flags(handle, "numFound");
+    if (checkNumFound == 0){
+      cmp = compare(a.getNumFound(), b.getNumFound(), 0, handle);
+      if (cmp != null) return ".numFound" + cmp;
+    } else if (checkNumFound != SKIP) {
+        assert (f & SKIPVAL) != 0;
+    }
 
     cmp = compare(a.getStart(), b.getStart(), 0, handle);
     if (cmp != null) return ".start" + cmp;


### PR DESCRIPTION
now `SearchGroupsResultTransformer` is concrete and the different behaviors (normal or skip second step) are achieved by delegating to a private class.